### PR TITLE
fix: change default task class from fix_ci to solve_issue

### DIFF
--- a/packages/fixbot/src/daemon/github-poller.ts
+++ b/packages/fixbot/src/daemon/github-poller.ts
@@ -48,7 +48,7 @@ export async function fetchLabeledIssues(
 	label: string,
 	token?: string,
 	logger?: (message: string) => void,
-): Promise<Array<{ number: number; title: string }>> {
+): Promise<Array<{ number: number; title: string; body: string | null }>> {
 	const path = `/repos/${owner}/${repo}/issues?labels=${encodeURIComponent(label)}&state=open&per_page=100`;
 	let response: Response;
 	try {
@@ -62,15 +62,15 @@ export async function fetchLabeledIssues(
 		logger?.(`[fixbot] github-poll warn: fetchLabeledIssues ${owner}/${repo} returned ${response.status}`);
 		return [];
 	}
-	let data: Array<{ number: number; title: string }>;
+	let data: Array<{ number: number; title: string; body: string | null }>;
 	try {
-		data = (await response.json()) as Array<{ number: number; title: string }>;
+		data = (await response.json()) as Array<{ number: number; title: string; body: string | null }>;
 	} catch (error) {
 		const msg = error instanceof Error ? error.message : String(error);
 		logger?.(`[fixbot] github-poll warn: fetchLabeledIssues ${owner}/${repo} malformed JSON: ${msg}`);
 		return [];
 	}
-	return data.map((issue) => ({ number: issue.number, title: issue.title }));
+	return data.map((issue) => ({ number: issue.number, title: issue.title, body: issue.body ?? null }));
 }
 
 export async function fetchLatestFailedRun(
@@ -177,7 +177,9 @@ export function buildGitHubJobSpec(
 	issueNumber: number,
 	runId: number,
 	labelName: string,
-	taskClass: TaskClass = "fix_ci",
+	taskClass: TaskClass = "solve_issue",
+	issueTitle?: string,
+	issueBody?: string,
 ): NormalizedJobSpecV1 {
 	const jobId = deriveGitHubJobId(repoUrl, issueNumber, labelName);
 	const spec: Record<string, unknown> = {
@@ -189,6 +191,8 @@ export function buildGitHubJobSpec(
 	};
 	if (taskClass === "fix_ci") {
 		spec.fixCi = { githubActionsRunId: runId };
+	} else if (taskClass === "solve_issue") {
+		spec.solveIssue = { issueNumber, ...(issueTitle ? { issueTitle } : {}), ...(issueBody ? { issueBody } : {}) };
 	}
 	return normalizeJobSpec(spec, "github-poll job");
 }
@@ -237,7 +241,7 @@ export async function pollGitHubRepos(
 
 		for (const labelName of labelsToQuery) {
 			// Determine task class for this label
-			const taskClass: TaskClass = repoConfig.taskClassOverrides?.[labelName] ?? "fix_ci";
+			const taskClass: TaskClass = repoConfig.taskClassOverrides?.[labelName] ?? "solve_issue";
 
 			const issues = await fetchLabeledIssues(owner, repo, labelName, githubConfig.token, logger);
 
@@ -277,6 +281,8 @@ export async function pollGitHubRepos(
 					runId,
 					labelName,
 					taskClass,
+					issue.title,
+					issue.body ?? undefined,
 				);
 				const artifactPaths = getArtifactPaths(resultsDir, jobSpec.jobId);
 				const envelope: DaemonJobEnvelopeV1 = {

--- a/packages/fixbot/test/daemon-github-poller.test.ts
+++ b/packages/fixbot/test/daemon-github-poller.test.ts
@@ -4,9 +4,9 @@ import {
 	buildGitHubJobSpec,
 	deriveGitHubJobId,
 	type GitHubEnqueueFn,
-	parseGitHubRepoPath,
 	pollGitHubRepos,
 } from "../src/daemon/github-poller";
+import { parseOwnerRepo } from "../src/daemon/github-reporter";
 import { DuplicateDaemonJobError } from "../src/daemon/job-store";
 import type { DaemonJobEnvelopeV1, NormalizedDaemonGitHubConfig } from "../src/types";
 
@@ -49,40 +49,53 @@ const BASE_CONFIG: NormalizedDaemonGitHubConfig = {
 	pollIntervalMs: 60_000,
 };
 
+const FIX_CI_CONFIG: NormalizedDaemonGitHubConfig = {
+	repos: [
+		{
+			url: "https://github.com/owner/repo",
+			baseBranch: "main",
+			triggerLabel: "fixbot",
+			taskClassOverrides: { fixbot: "fix_ci" },
+		},
+	],
+	token: "fake-token",
+	pollIntervalMs: 60_000,
+};
+
 const RESULTS_DIR = "/tmp/fixbot-test-results";
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("parseGitHubRepoPath", () => {
+describe("parseOwnerRepo", () => {
 	it("handles plain https URL", () => {
-		expect(parseGitHubRepoPath("https://github.com/owner/repo")).toEqual({ owner: "owner", repo: "repo" });
+		expect(parseOwnerRepo("https://github.com/owner/repo")).toEqual({ owner: "owner", repo: "repo" });
 	});
 
 	it("handles URL with .git suffix", () => {
-		expect(parseGitHubRepoPath("https://github.com/owner/repo.git")).toEqual({ owner: "owner", repo: "repo" });
+		expect(parseOwnerRepo("https://github.com/owner/repo.git")).toEqual({ owner: "owner", repo: "repo" });
 	});
 
 	it("handles URL with trailing slash", () => {
-		expect(parseGitHubRepoPath("https://github.com/owner/repo/")).toEqual({ owner: "owner", repo: "repo" });
+		expect(parseOwnerRepo("https://github.com/owner/repo/")).toEqual({ owner: "owner", repo: "repo" });
 	});
 
 	it("handles URL with .git and trailing slash", () => {
 		// .git before trailing slash — strip trailing slash first then .git
-		expect(parseGitHubRepoPath("https://github.com/owner/repo.git/")).toEqual({ owner: "owner", repo: "repo" });
+		expect(parseOwnerRepo("https://github.com/owner/repo.git/")).toEqual({ owner: "owner", repo: "repo" });
 	});
 
 	it("throws on invalid URL with too many segments", () => {
-		expect(() => parseGitHubRepoPath("https://github.com/a/b/c")).toThrow("exactly owner/repo");
+		expect(() => parseOwnerRepo("https://github.com/a/b/c")).toThrow("exactly owner/repo");
 	});
 
 	it("throws on invalid URL with too few segments", () => {
-		expect(() => parseGitHubRepoPath("https://github.com/owner")).toThrow("exactly owner/repo");
+		expect(() => parseOwnerRepo("https://github.com/owner")).toThrow("exactly owner/repo");
 	});
 
 	it("throws on non-URL string", () => {
-		expect(() => parseGitHubRepoPath("not-a-url")).toThrow("Invalid GitHub repo URL");
+		expect(() => parseOwnerRepo("not-a-url")).toThrow("owner/repo");
 	});
 });
 
@@ -104,8 +117,8 @@ describe("deriveGitHubJobId", () => {
 });
 
 describe("buildGitHubJobSpec", () => {
-	it("returns a normalized job spec with fix_ci task class", () => {
-		const spec = buildGitHubJobSpec("https://github.com/owner/repo", "main", 10, 12345, "fixbot");
+	it("returns a normalized job spec with explicit fix_ci task class", () => {
+		const spec = buildGitHubJobSpec("https://github.com/owner/repo", "main", 10, 12345, "fixbot", "fix_ci");
 		expect(spec.version).toBe("fixbot.job/v1");
 		expect(spec.taskClass).toBe("fix_ci");
 		expect(spec.repo.url).toBe("https://github.com/owner/repo");
@@ -115,6 +128,27 @@ describe("buildGitHubJobSpec", () => {
 		expect(spec.execution.timeoutMs).toBe(600_000);
 		expect(spec.execution.memoryLimitMb).toBe(4096);
 		expect(spec.jobId).toMatch(/^gh-[a-f0-9]{16}$/);
+	});
+
+	it("defaults to solve_issue with solveIssue context", () => {
+		const spec = buildGitHubJobSpec("https://github.com/owner/repo", "main", 10, 0, "fixbot");
+		expect(spec.taskClass).toBe("solve_issue");
+		expect(spec.solveIssue).toBeDefined();
+		expect(spec.solveIssue!.issueNumber).toBe(10);
+		expect(spec.fixCi).toBeUndefined();
+	});
+
+	it("includes issueTitle in solveIssue context when provided", () => {
+		const spec = buildGitHubJobSpec(
+			"https://github.com/owner/repo",
+			"main",
+			10,
+			0,
+			"fixbot",
+			"solve_issue",
+			"Fix the login bug",
+		);
+		expect(spec.solveIssue!.issueTitle).toBe("Fix the login bug");
 	});
 });
 
@@ -126,7 +160,7 @@ describe("pollGitHubRepos", () => {
 		mock.restore();
 	});
 
-	it("enqueues one job for a labeled issue with a failing run", async () => {
+	it("enqueues one fix_ci job for a labeled issue with a failing run", async () => {
 		globalThis.fetch = createMockFetch([
 			{
 				urlPattern: "/repos/owner/repo/issues?labels=fixbot",
@@ -151,7 +185,7 @@ describe("pollGitHubRepos", () => {
 		const enqueued: DaemonJobEnvelopeV1[] = [];
 		const enqueueFn: GitHubEnqueueFn = (envelope) => enqueued.push(envelope);
 
-		const result = await pollGitHubRepos(BASE_CONFIG, RESULTS_DIR, enqueueFn);
+		const result = await pollGitHubRepos(FIX_CI_CONFIG, RESULTS_DIR, enqueueFn);
 
 		expect(result.enqueued).toHaveLength(1);
 		expect(result.skipped).toBe(0);
@@ -191,7 +225,7 @@ describe("pollGitHubRepos", () => {
 		expect(result.enqueued).toHaveLength(0);
 	});
 
-	it("no failing run skips with zero enqueue", async () => {
+	it("no failing run skips with zero enqueue for fix_ci override", async () => {
 		globalThis.fetch = createMockFetch([
 			{
 				urlPattern: "/repos/owner/repo/issues?labels=fixbot",
@@ -209,7 +243,7 @@ describe("pollGitHubRepos", () => {
 		]);
 
 		const enqueueFn = mock(() => undefined) as unknown as GitHubEnqueueFn;
-		const result = await pollGitHubRepos(BASE_CONFIG, RESULTS_DIR, enqueueFn);
+		const result = await pollGitHubRepos(FIX_CI_CONFIG, RESULTS_DIR, enqueueFn);
 
 		expect(enqueueFn).not.toHaveBeenCalled();
 		expect(result.skipped).toBe(1);
@@ -237,7 +271,7 @@ describe("pollGitHubRepos", () => {
 			throw new DuplicateDaemonJobError("gh-test", [{ kind: "queue", path: "/fake" }]);
 		};
 
-		const result = await pollGitHubRepos(BASE_CONFIG, RESULTS_DIR, enqueueFn);
+		const result = await pollGitHubRepos(FIX_CI_CONFIG, RESULTS_DIR, enqueueFn);
 
 		expect(result.skipped).toBe(1);
 		expect(result.errors).toBe(0);
@@ -387,21 +421,17 @@ describe("pollGitHubRepos", () => {
 		expect(enqueued[0].submission.githubActionsRunId).toBeUndefined();
 	});
 
-	it("triggerLabel without override still produces fix_ci (backward compat)", async () => {
-		// Uses BASE_CONFIG which has no taskClassOverrides
+	it("triggerLabel without override produces solve_issue by default", async () => {
+		// Uses BASE_CONFIG which has no taskClassOverrides — default is now solve_issue
 		globalThis.fetch = createMockFetch([
 			{
 				urlPattern: "/repos/owner/repo/issues?labels=fixbot",
-				response: { status: 200, body: [{ number: 7, title: "CI broken" }] },
+				response: { status: 200, body: [{ number: 7, title: "Fix the login bug" }] },
 			},
 			{
 				urlPattern: "/repos/owner/repo/issues/7/comments",
 				method: "GET",
 				response: { status: 200, body: [] },
-			},
-			{
-				urlPattern: "/repos/owner/repo/actions/runs",
-				response: { status: 200, body: { workflow_runs: [{ id: 99001 }] } },
 			},
 			{
 				urlPattern: "/repos/owner/repo/issues/7/comments",
@@ -416,7 +446,10 @@ describe("pollGitHubRepos", () => {
 		const result = await pollGitHubRepos(BASE_CONFIG, RESULTS_DIR, enqueueFn);
 
 		expect(result.enqueued).toHaveLength(1);
-		expect(enqueued[0].job.taskClass).toBe("fix_ci");
-		expect(enqueued[0].job.fixCi).toBeDefined();
+		expect(enqueued[0].job.taskClass).toBe("solve_issue");
+		expect(enqueued[0].job.solveIssue).toBeDefined();
+		expect(enqueued[0].job.solveIssue!.issueNumber).toBe(7);
+		expect(enqueued[0].job.solveIssue!.issueTitle).toBe("Fix the login bug");
+		expect(enqueued[0].job.fixCi).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
- Change default task class from `fix_ci` to `solve_issue` so labeled issues are actually processed
- Add issue body passthrough to `solveIssue` context for richer agent context
- Fix broken test import (`parseGitHubRepoPath` → `parseOwnerRepo` from `github-reporter`)
- Update all tests for new default behavior

## Context
The daemon's GitHub poller defaulted every labeled issue to `fix_ci`, which requires a failing CI run on the base branch. When no CI failure exists, issues are silently skipped. This meant the "fixbot" trigger label did nothing unless CI was broken.

`solve_issue` is the natural default — it reads the issue and fixes it without needing CI context. Users wanting `fix_ci` behavior can use `taskClassOverrides`.

## Pre-Landing Review
No issues found. Codex P2 (missing issue body) auto-fixed.

## Test Coverage
All new code paths covered:
- Default `solve_issue` with `solveIssue` context
- `issueTitle` passthrough
- Explicit `fix_ci` override behavior preserved
- Tests: 39 pass, 0 fail

## Test plan
- [x] `bun test packages/fixbot/test/daemon-github-poller.test.ts` — 22 pass
- [x] `bun test packages/fixbot/test/contracts.test.ts` — 17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)