### PR TITLE
feat: fixbot status dashboard CLI with --json support

### DIFF
--- a/packages/fixbot/src/commands/status.ts
+++ b/packages/fixbot/src/commands/status.ts
@@ -29,8 +29,8 @@ export default class Status extends Command {
 			issues = result.issues;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			process.stdout.write(`fixbot daemon is not running (${message})\n`);
-			process.exitCode = 2;
+			process.stderr.write(`error: fixbot daemon is not running — ${message}\n`);
+			process.exitCode = 1;
 			return;
 		}
 

--- a/packages/fixbot/src/commands/status.ts
+++ b/packages/fixbot/src/commands/status.ts
@@ -1,0 +1,47 @@
+import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { DEFAULT_DAEMON_CONFIG_PATH } from "../config";
+
+export default class Status extends Command {
+	static description = "Show fixbot daemon status dashboard";
+
+	static flags = {
+		config: Flags.string({
+			description: "Path to daemon config file",
+			default: DEFAULT_DAEMON_CONFIG_PATH,
+		}),
+		json: Flags.boolean({
+			description: "Output raw JSON status",
+			default: false,
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(Status);
+		const configPath = flags.config;
+
+		let status: import("../types").DaemonStatusV1;
+		let issues: string[];
+
+		try {
+			const { getDaemonStatusFromConfigFile } = await import("../daemon/service");
+			const result = await getDaemonStatusFromConfigFile(configPath);
+			status = result.status;
+			issues = result.issues;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			process.stdout.write(`fixbot daemon is not running (${message})\n`);
+			process.exitCode = 2;
+			return;
+		}
+
+		if (flags.json) {
+			process.stdout.write(JSON.stringify({ status, issues }, null, 2) + "\n");
+			return;
+		}
+
+		const { createDaemonStatusSnapshot } = await import("../daemon/status-store");
+		const { formatStatusDashboard } = await import("../daemon/status-formatter");
+		const snapshot = createDaemonStatusSnapshot(status);
+		process.stdout.write(formatStatusDashboard(snapshot, issues));
+	}
+}

--- a/packages/fixbot/src/daemon/status-formatter.ts
+++ b/packages/fixbot/src/daemon/status-formatter.ts
@@ -244,9 +244,11 @@ export function formatStatusDashboard(
 	const repoStats = computeRepoStats(status.recentResults, DEFAULT_WINDOW_MS, now);
 	if (repoStats.length > 0) {
 		lines.push(section("Per-Repo Stats (last 7 days)"));
+		const maxRepoLen = Math.max(...repoStats.map((s) => s.repo.length));
 		for (const s of repoStats) {
+			const paddedRepo = s.repo.padEnd(maxRepoLen);
 			lines.push(
-				`  ${s.repo}  ${s.total} jobs  ${chalk.green(`${s.success} ok`)}  ${chalk.red(`${s.failed} fail`)}  ${s.successRate}`,
+				`  ${paddedRepo}  ${String(s.total).padStart(3)} jobs  ${chalk.green(`${s.success} ok`)}  ${chalk.red(`${s.failed} fail`)}  ${s.successRate}`,
 			);
 		}
 	}

--- a/packages/fixbot/src/daemon/status-formatter.ts
+++ b/packages/fixbot/src/daemon/status-formatter.ts
@@ -1,0 +1,255 @@
+import chalk from "chalk";
+import type {
+	DaemonRecentResultSummaryV1,
+	DaemonStatusSnapshotV1,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// RepoStats
+// ---------------------------------------------------------------------------
+
+export interface RepoStats {
+	repo: string;
+	total: number;
+	success: number;
+	failed: number;
+	timeout: number;
+	successRate: string;
+}
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Format milliseconds as human-readable duration.
+ * Examples: "2h 14m", "3m 12s", "0s"
+ */
+export function formatDuration(ms: number): string {
+	if (ms <= 0) return "0s";
+
+	const totalSeconds = Math.floor(ms / 1_000);
+	if (totalSeconds === 0) return "0s";
+
+	const days = Math.floor(totalSeconds / 86_400);
+	const hours = Math.floor((totalSeconds % 86_400) / 3_600);
+	const minutes = Math.floor((totalSeconds % 3_600) / 60);
+	const seconds = totalSeconds % 60;
+
+	const parts: string[] = [];
+	if (days > 0) parts.push(`${days}d`);
+	if (hours > 0) parts.push(`${hours}h`);
+	if (minutes > 0) parts.push(`${minutes}m`);
+
+	// Omit seconds when days are present
+	if (days === 0 && seconds > 0) parts.push(`${seconds}s`);
+
+	return parts.length > 0 ? parts.join(" ") : "0s";
+}
+
+// ---------------------------------------------------------------------------
+// formatUptime
+// ---------------------------------------------------------------------------
+
+/**
+ * Format uptime from an ISO timestamp. Returns "n/a" for null/invalid inputs.
+ */
+export function formatUptime(startedAt: string | null | undefined, now: number = Date.now()): string {
+	if (startedAt == null) return "n/a";
+	const startMs = Date.parse(startedAt);
+	if (Number.isNaN(startMs)) return "n/a";
+	const elapsed = now - startMs;
+	if (elapsed <= 0) return "0s";
+	return formatDuration(elapsed);
+}
+
+// ---------------------------------------------------------------------------
+// formatElapsed
+// ---------------------------------------------------------------------------
+
+/**
+ * Format elapsed time from an ISO timestamp. Returns "n/a" for undefined/invalid inputs.
+ */
+export function formatElapsed(startedAt: string | undefined, now: number = Date.now()): string {
+	if (startedAt === undefined) return "n/a";
+	const startMs = Date.parse(startedAt);
+	if (Number.isNaN(startMs)) return "n/a";
+	const elapsed = now - startMs;
+	if (elapsed <= 0) return "0s";
+	return formatDuration(elapsed);
+}
+
+// ---------------------------------------------------------------------------
+// computeRepoStats
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60 * 1_000; // 7 days
+
+/**
+ * Group recent results by repo, compute counts and success rate.
+ * Results outside the time window are excluded.
+ */
+export function computeRepoStats(
+	results: DaemonRecentResultSummaryV1[],
+	windowMs: number = DEFAULT_WINDOW_MS,
+	now: number = Date.now(),
+): RepoStats[] {
+	const cutoff = now - windowMs;
+
+	const map = new Map<string, { success: number; failed: number; timeout: number }>();
+
+	for (const r of results) {
+		const finishedMs = Date.parse(r.finishedAt);
+		if (finishedMs < cutoff) continue;
+
+		const repo = r.submission?.githubRepo ?? "cli";
+		let entry = map.get(repo);
+		if (!entry) {
+			entry = { success: 0, failed: 0, timeout: 0 };
+			map.set(repo, entry);
+		}
+
+		if (r.status === "success") entry.success++;
+		else if (r.status === "timeout") entry.timeout++;
+		else entry.failed++;
+	}
+
+	const stats: RepoStats[] = [];
+	for (const [repo, counts] of map) {
+		const total = counts.success + counts.failed + counts.timeout;
+		const rate = total > 0 ? Math.round((counts.success / total) * 100) : 0;
+		stats.push({
+			repo,
+			total,
+			success: counts.success,
+			failed: counts.failed,
+			timeout: counts.timeout,
+			successRate: `${rate}%`,
+		});
+	}
+
+	// Sort by total descending, then alphabetically
+	stats.sort((a, b) => {
+		if (b.total !== a.total) return b.total - a.total;
+		return a.repo.localeCompare(b.repo);
+	});
+
+	return stats;
+}
+
+// ---------------------------------------------------------------------------
+// formatStatusDashboard
+// ---------------------------------------------------------------------------
+
+function stateColor(state: string): (text: string) => string {
+	switch (state) {
+		case "idle":
+			return chalk.green;
+		case "running":
+			return chalk.blue;
+		case "degraded":
+			return chalk.yellow;
+		case "error":
+			return chalk.red;
+		default:
+			return chalk.gray;
+	}
+}
+
+function section(title: string): string {
+	return `\n${chalk.bold.underline(title)}\n`;
+}
+
+/**
+ * Render a full colored status dashboard from a DaemonStatusSnapshotV1.
+ */
+export function formatStatusDashboard(
+	status: DaemonStatusSnapshotV1,
+	issues: string[] = [],
+	now: number = Date.now(),
+): string {
+	const lines: string[] = [];
+
+	// ── Daemon Status ──
+	lines.push(section("Daemon Status"));
+
+	const stateStr = stateColor(status.state)(status.state);
+	lines.push(`  State:     ${stateStr}`);
+	lines.push(`  PID:       ${status.pid != null ? status.pid : "none"}`);
+	lines.push(`  Uptime:    ${formatUptime(status.startedAt, now)}`);
+
+	if (status.heartbeatAgeMs != null) {
+		lines.push(`  Heartbeat: ${formatDuration(status.heartbeatAgeMs)} ago`);
+	} else {
+		lines.push("  Heartbeat: never");
+	}
+
+	if (status.lastError) {
+		const code = status.lastError.code ? `[${status.lastError.code}] ` : "";
+		lines.push(`  ${chalk.red("Last Error:")} ${code}${status.lastError.message}`);
+	}
+
+	if (issues && issues.length > 0) {
+		lines.push(`  ${chalk.yellow("Issues:")} ${issues.join("; ")}`);
+	}
+
+	// ── Queue ──
+	lines.push(section("Queue"));
+	lines.push(`  Depth: ${status.queue.depth}`);
+
+	if (status.queue.preview.length > 0) {
+		for (const job of status.queue.preview) {
+			const enq = job.enqueuedAt ? ` (enqueued ${job.enqueuedAt})` : "";
+			lines.push(`    ${chalk.dim("•")} ${job.jobId}${enq}`);
+		}
+		const remaining = status.queue.depth - status.queue.preview.length;
+		if (remaining > 0) {
+			lines.push(`    ${chalk.dim(`... and ${remaining} more`)}`);
+		}
+	}
+
+	// ── Active Job ──
+	lines.push(section("Active Job"));
+
+	if (status.activeJob) {
+		lines.push(`  Job ID:  ${status.activeJob.jobId}`);
+		lines.push(`  State:   ${status.activeJob.state}`);
+		lines.push(`  Elapsed: ${formatElapsed(status.activeJob.startedAt, now)}`);
+	} else {
+		lines.push(`  ${chalk.dim("none")}`);
+	}
+
+	// ── Recent Results ──
+	lines.push(section("Recent Results"));
+
+	if (status.recentResults.length === 0) {
+		lines.push(`  ${chalk.dim("none")}`);
+	} else {
+		const maxDisplay = 10;
+		const displayed = status.recentResults.slice(0, maxDisplay);
+		for (const r of displayed) {
+			const statusColor = r.status === "success" ? chalk.green : r.status === "failed" ? chalk.red : chalk.yellow;
+			let line = `  ${r.jobId} ${statusColor(r.status)}`;
+			if (r.summary) line += ` - ${r.summary}`;
+			if (r.failureReason) line += ` ${chalk.dim(`(${r.failureReason})`)}`;
+			lines.push(line);
+		}
+		const remaining = status.recentResults.length - maxDisplay;
+		if (remaining > 0) {
+			lines.push(`  ${chalk.dim(`... and ${remaining} more`)}`);
+		}
+	}
+
+	// ── Per-Repo Stats ──
+	const repoStats = computeRepoStats(status.recentResults, DEFAULT_WINDOW_MS, now);
+	if (repoStats.length > 0) {
+		lines.push(section("Per-Repo Stats (last 7 days)"));
+		for (const s of repoStats) {
+			lines.push(
+				`  ${s.repo}  ${s.total} jobs  ${chalk.green(`${s.success} ok`)}  ${chalk.red(`${s.failed} fail`)}  ${s.successRate}`,
+			);
+		}
+	}
+
+	return lines.join("\n") + "\n";
+}

--- a/packages/fixbot/src/index.ts
+++ b/packages/fixbot/src/index.ts
@@ -116,4 +116,12 @@ export {
 } from "./internal-runner";
 export { parseResultMarkers } from "./markers";
 export { runJob } from "./runner";
+export {
+	computeRepoStats,
+	formatDuration,
+	formatElapsed,
+	formatStatusDashboard,
+	formatUptime,
+	type RepoStats,
+} from "./daemon/status-formatter";
 export * from "./types";

--- a/packages/fixbot/test/status-formatter.test.ts
+++ b/packages/fixbot/test/status-formatter.test.ts
@@ -1,0 +1,461 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import chalk from "chalk";
+import type {
+	DaemonRecentResultSummaryV1,
+	DaemonStatusSnapshotV1,
+} from "../src/types";
+import {
+	computeRepoStats,
+	formatDuration,
+	formatElapsed,
+	formatStatusDashboard,
+	formatUptime,
+} from "../src/daemon/status-formatter";
+
+// Disable chalk colors for deterministic assertions
+beforeAll(() => {
+	chalk.level = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSnapshot(overrides: Partial<DaemonStatusSnapshotV1> = {}): DaemonStatusSnapshotV1 {
+	return {
+		version: "fixbot.daemon-status/v1",
+		state: "idle",
+		pid: 12345,
+		startedAt: "2026-03-20T10:00:00.000Z",
+		heartbeatAt: "2026-03-20T10:05:00.000Z",
+		heartbeatAgeMs: 3_000,
+		lastTransitionAt: "2026-03-20T10:00:01.000Z",
+		paths: {
+			stateDir: "/tmp/state",
+			resultsDir: "/tmp/results",
+			statusFile: "/tmp/state/daemon-status.json",
+			pidFile: "/tmp/state/daemon.pid",
+			lockFile: "/tmp/state/daemon.lock",
+		},
+		lastError: null,
+		queue: { depth: 0, preview: [], previewTruncated: false },
+		activeJob: null,
+		recentResults: [],
+		...overrides,
+	};
+}
+
+function makeResult(
+	overrides: Partial<DaemonRecentResultSummaryV1> = {},
+): DaemonRecentResultSummaryV1 {
+	return {
+		jobId: "job-1",
+		status: "success",
+		finishedAt: "2026-03-20T10:00:00.000Z",
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+	it("returns 0s for zero milliseconds", () => {
+		expect(formatDuration(0)).toBe("0s");
+	});
+
+	it("returns 0s for negative input", () => {
+		expect(formatDuration(-5000)).toBe("0s");
+	});
+
+	it("formats seconds only", () => {
+		expect(formatDuration(45_000)).toBe("45s");
+	});
+
+	it("formats minutes and seconds", () => {
+		expect(formatDuration(125_000)).toBe("2m 5s");
+	});
+
+	it("formats hours, minutes, and seconds", () => {
+		expect(formatDuration(3_723_000)).toBe("1h 2m 3s");
+	});
+
+	it("formats days and hours without seconds", () => {
+		// 2 days, 3 hours = 183600s
+		expect(formatDuration(183_600_000)).toBe("2d 3h");
+	});
+
+	it("omits seconds when days are present", () => {
+		// 1 day, 0 hours, 5 minutes, 30 seconds
+		const ms = (86_400 + 5 * 60 + 30) * 1_000;
+		expect(formatDuration(ms)).toBe("1d 5m");
+	});
+
+	it("formats sub-second as 0s", () => {
+		expect(formatDuration(999)).toBe("0s");
+	});
+
+	it("formats exactly one day", () => {
+		expect(formatDuration(86_400_000)).toBe("1d");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatUptime
+// ---------------------------------------------------------------------------
+
+describe("formatUptime", () => {
+	it("returns n/a for null startedAt", () => {
+		expect(formatUptime(null)).toBe("n/a");
+	});
+
+	it("returns n/a for invalid date string", () => {
+		expect(formatUptime("not-a-date")).toBe("n/a");
+	});
+
+	it("returns 0s when now equals startedAt", () => {
+		const t = Date.parse("2026-03-20T10:00:00.000Z");
+		expect(formatUptime("2026-03-20T10:00:00.000Z", t)).toBe("0s");
+	});
+
+	it("returns formatted duration for valid uptime", () => {
+		const started = "2026-03-20T10:00:00.000Z";
+		const now = Date.parse("2026-03-20T12:30:45.000Z");
+		expect(formatUptime(started, now)).toBe("2h 30m 45s");
+	});
+
+	it("returns 0s when now is before startedAt", () => {
+		const started = "2026-03-20T12:00:00.000Z";
+		const now = Date.parse("2026-03-20T10:00:00.000Z");
+		expect(formatUptime(started, now)).toBe("0s");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatElapsed
+// ---------------------------------------------------------------------------
+
+describe("formatElapsed", () => {
+	it("returns n/a for undefined startedAt", () => {
+		expect(formatElapsed(undefined)).toBe("n/a");
+	});
+
+	it("returns n/a for invalid date", () => {
+		expect(formatElapsed("garbage")).toBe("n/a");
+	});
+
+	it("returns formatted elapsed time", () => {
+		const started = "2026-03-20T10:00:00.000Z";
+		const now = Date.parse("2026-03-20T10:05:30.000Z");
+		expect(formatElapsed(started, now)).toBe("5m 30s");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// computeRepoStats
+// ---------------------------------------------------------------------------
+
+describe("computeRepoStats", () => {
+	it("returns empty array for empty results", () => {
+		expect(computeRepoStats([])).toEqual([]);
+	});
+
+	it("groups by githubRepo and falls back to cli", () => {
+		const results: DaemonRecentResultSummaryV1[] = [
+			makeResult({
+				jobId: "j1",
+				status: "success",
+				finishedAt: "2026-03-20T10:00:00.000Z",
+				submission: { kind: "github-label", githubRepo: "owner/repo-a" },
+			}),
+			makeResult({
+				jobId: "j2",
+				status: "failed",
+				finishedAt: "2026-03-20T10:01:00.000Z",
+				submission: { kind: "cli" },
+			}),
+			makeResult({
+				jobId: "j3",
+				status: "success",
+				finishedAt: "2026-03-20T10:02:00.000Z",
+			}),
+		];
+		const now = Date.parse("2026-03-20T11:00:00.000Z");
+		const stats = computeRepoStats(results, 7 * 24 * 60 * 60 * 1_000, now);
+
+		expect(stats.length).toBe(2);
+		const cliStats = stats.find((s) => s.repo === "cli");
+		const repoStats = stats.find((s) => s.repo === "owner/repo-a");
+		expect(cliStats).toBeDefined();
+		expect(cliStats!.total).toBe(2);
+		expect(cliStats!.failed).toBe(1);
+		expect(cliStats!.success).toBe(1);
+		expect(repoStats).toBeDefined();
+		expect(repoStats!.total).toBe(1);
+		expect(repoStats!.success).toBe(1);
+		expect(repoStats!.successRate).toBe("100%");
+	});
+
+	it("excludes results outside the time window", () => {
+		const now = Date.parse("2026-03-20T10:00:00.000Z");
+		const results: DaemonRecentResultSummaryV1[] = [
+			makeResult({
+				jobId: "old",
+				status: "success",
+				finishedAt: "2026-03-01T10:00:00.000Z", // 19 days ago
+			}),
+			makeResult({
+				jobId: "recent",
+				status: "success",
+				finishedAt: "2026-03-19T10:00:00.000Z", // 1 day ago
+			}),
+		];
+		const stats = computeRepoStats(results, 7 * 24 * 60 * 60 * 1_000, now);
+		expect(stats.length).toBe(1);
+		expect(stats[0].total).toBe(1);
+	});
+
+	it("counts timeout status separately", () => {
+		const now = Date.parse("2026-03-20T10:00:00.000Z");
+		const results: DaemonRecentResultSummaryV1[] = [
+			makeResult({ status: "timeout", finishedAt: "2026-03-20T09:00:00.000Z" }),
+			makeResult({ status: "success", finishedAt: "2026-03-20T09:00:00.000Z", jobId: "j2" }),
+		];
+		const stats = computeRepoStats(results, 7 * 24 * 60 * 60 * 1_000, now);
+		expect(stats[0].timeout).toBe(1);
+		expect(stats[0].success).toBe(1);
+		expect(stats[0].successRate).toBe("50%");
+	});
+
+	it("sorts by total descending then alphabetically", () => {
+		const now = Date.parse("2026-03-20T10:00:00.000Z");
+		const results: DaemonRecentResultSummaryV1[] = [
+			makeResult({
+				jobId: "a1",
+				finishedAt: "2026-03-20T09:00:00.000Z",
+				submission: { kind: "github-label", githubRepo: "z-repo" },
+			}),
+			makeResult({
+				jobId: "b1",
+				finishedAt: "2026-03-20T09:01:00.000Z",
+				submission: { kind: "github-label", githubRepo: "a-repo" },
+			}),
+			makeResult({
+				jobId: "b2",
+				finishedAt: "2026-03-20T09:02:00.000Z",
+				submission: { kind: "github-label", githubRepo: "a-repo" },
+			}),
+		];
+		const stats = computeRepoStats(results, 7 * 24 * 60 * 60 * 1_000, now);
+		expect(stats[0].repo).toBe("a-repo");
+		expect(stats[1].repo).toBe("z-repo");
+	});
+
+	it("computes 0% success rate when all failed", () => {
+		const now = Date.parse("2026-03-20T10:00:00.000Z");
+		const results: DaemonRecentResultSummaryV1[] = [
+			makeResult({ status: "failed", finishedAt: "2026-03-20T09:00:00.000Z" }),
+			makeResult({ status: "failed", finishedAt: "2026-03-20T09:01:00.000Z", jobId: "j2" }),
+		];
+		const stats = computeRepoStats(results, 7 * 24 * 60 * 60 * 1_000, now);
+		expect(stats[0].successRate).toBe("0%");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatStatusDashboard
+// ---------------------------------------------------------------------------
+
+describe("formatStatusDashboard", () => {
+	it("renders the daemon status section with state and PID", () => {
+		const output = formatStatusDashboard(makeSnapshot());
+		expect(output).toContain("Daemon Status");
+		expect(output).toContain("State:     idle");
+		expect(output).toContain("PID:       12345");
+	});
+
+	it("renders uptime from startedAt", () => {
+		const now = Date.parse("2026-03-20T12:00:00.000Z");
+		const output = formatStatusDashboard(
+			makeSnapshot({ startedAt: "2026-03-20T10:00:00.000Z" }),
+			[],
+			now,
+		);
+		expect(output).toContain("Uptime:    2h");
+	});
+
+	it("renders heartbeat age", () => {
+		const output = formatStatusDashboard(makeSnapshot({ heartbeatAgeMs: 5_000 }));
+		expect(output).toContain("Heartbeat: 5s ago");
+	});
+
+	it("renders 'never' for null heartbeat", () => {
+		const output = formatStatusDashboard(makeSnapshot({ heartbeatAgeMs: null }));
+		expect(output).toContain("Heartbeat: never");
+	});
+
+	it("renders last error when present", () => {
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				lastError: { message: "something broke", code: "BROKEN", at: "2026-03-20T10:00:00.000Z" },
+			}),
+		);
+		expect(output).toContain("[BROKEN] something broke");
+	});
+
+	it("renders issues when present", () => {
+		const output = formatStatusDashboard(makeSnapshot(), ["pid mismatch", "stale heartbeat"]);
+		expect(output).toContain("pid mismatch; stale heartbeat");
+	});
+
+	it("renders empty queue", () => {
+		const output = formatStatusDashboard(makeSnapshot());
+		expect(output).toContain("Queue");
+		expect(output).toContain("Depth: 0");
+	});
+
+	it("renders queue with preview items", () => {
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				queue: {
+					depth: 3,
+					preview: [
+						{ jobId: "job-100", enqueuedAt: "2026-03-20T10:00:00.000Z" },
+						{ jobId: "job-101" },
+					],
+					previewTruncated: true,
+				},
+			}),
+		);
+		expect(output).toContain("Depth: 3");
+		expect(output).toContain("job-100");
+		expect(output).toContain("job-101");
+		expect(output).toContain("... and 1 more");
+	});
+
+	it("renders no active job", () => {
+		const output = formatStatusDashboard(makeSnapshot());
+		expect(output).toContain("Active Job");
+		expect(output).toContain("none");
+	});
+
+	it("renders active job with elapsed time", () => {
+		const now = Date.parse("2026-03-20T10:10:00.000Z");
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				activeJob: {
+					jobId: "job-42",
+					state: "running",
+					startedAt: "2026-03-20T10:05:00.000Z",
+				},
+			}),
+			[],
+			now,
+		);
+		expect(output).toContain("Job ID:  job-42");
+		expect(output).toContain("State:   running");
+		expect(output).toContain("Elapsed: 5m");
+	});
+
+	it("renders empty recent results", () => {
+		const output = formatStatusDashboard(makeSnapshot());
+		expect(output).toContain("Recent Results");
+		expect(output).toContain("none");
+	});
+
+	it("renders recent results with status and summary", () => {
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				recentResults: [
+					makeResult({ jobId: "j1", status: "success", summary: "fixed CI" }),
+					makeResult({ jobId: "j2", status: "failed", failureReason: "OOM" }),
+				],
+			}),
+		);
+		expect(output).toContain("j1 success - fixed CI");
+		expect(output).toContain("j2 failed");
+		expect(output).toContain("(OOM)");
+	});
+
+	it("truncates recent results display to 10", () => {
+		const results: DaemonRecentResultSummaryV1[] = [];
+		for (let i = 0; i < 15; i++) {
+			results.push(
+				makeResult({
+					jobId: `job-${i}`,
+					finishedAt: `2026-03-20T10:${String(i).padStart(2, "0")}:00.000Z`,
+				}),
+			);
+		}
+		const output = formatStatusDashboard(makeSnapshot({ recentResults: results }));
+		expect(output).toContain("job-0");
+		expect(output).toContain("job-9");
+		expect(output).not.toContain("job-10 success");
+		expect(output).toContain("... and 5 more");
+	});
+
+	it("renders per-repo stats section", () => {
+		const now = Date.parse("2026-03-20T11:00:00.000Z");
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				recentResults: [
+					makeResult({
+						jobId: "j1",
+						status: "success",
+						finishedAt: "2026-03-20T10:00:00.000Z",
+						submission: { kind: "github-label", githubRepo: "owner/repo" },
+					}),
+					makeResult({
+						jobId: "j2",
+						status: "failed",
+						finishedAt: "2026-03-20T10:01:00.000Z",
+						submission: { kind: "github-label", githubRepo: "owner/repo" },
+					}),
+				],
+			}),
+			[],
+			now,
+		);
+		expect(output).toContain("Per-Repo Stats (last 7 days)");
+		expect(output).toContain("owner/repo");
+		expect(output).toContain("2 jobs");
+		expect(output).toContain("50%");
+	});
+
+	it("omits per-repo stats when no results in window", () => {
+		const now = Date.parse("2026-04-01T10:00:00.000Z");
+		const output = formatStatusDashboard(
+			makeSnapshot({
+				recentResults: [
+					makeResult({
+						finishedAt: "2026-03-01T10:00:00.000Z", // way outside 7-day window
+					}),
+				],
+			}),
+			[],
+			now,
+		);
+		expect(output).not.toContain("Per-Repo Stats");
+	});
+
+	it("renders PID as none when null", () => {
+		const output = formatStatusDashboard(makeSnapshot({ pid: null }));
+		expect(output).toContain("PID:       none");
+	});
+
+	it("renders degraded state", () => {
+		const output = formatStatusDashboard(makeSnapshot({ state: "degraded" }));
+		expect(output).toContain("State:     degraded");
+	});
+
+	it("renders error state", () => {
+		const output = formatStatusDashboard(makeSnapshot({ state: "error" }));
+		expect(output).toContain("State:     error");
+	});
+
+	it("renders n/a uptime when startedAt is null", () => {
+		const output = formatStatusDashboard(makeSnapshot({ startedAt: null }));
+		expect(output).toContain("Uptime:    n/a");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `fixbot status` command that displays a colored terminal dashboard showing daemon state, queue depth, active job, recent results, and per-repo stats
- Support `--json` flag for machine-readable output and `--config` to specify daemon config path
- Pure formatting functions (`formatDuration`, `formatUptime`, `formatElapsed`, `computeRepoStats`, `formatStatusDashboard`) exported from package index for reuse

## Files
- **New:** `packages/fixbot/src/commands/status.ts` — CLI command entry point
- **New:** `packages/fixbot/src/daemon/status-formatter.ts` — pure formatting/rendering functions
- **New:** `packages/fixbot/test/status-formatter.test.ts` — 42 tests covering all formatters
- **Modified:** `packages/fixbot/src/index.ts` — re-export formatter utilities

## Test plan
- [x] `bun test test/status-formatter.test.ts` — 42 tests pass

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)