### PR TITLE
feat: per-repo .fixbot/config.yml for model and excludePaths

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,8 @@
         "@oh-my-pi/pi-ai": "workspace:*",
         "@oh-my-pi/pi-coding-agent": "workspace:*",
         "@oh-my-pi/pi-utils": "workspace:*",
+        "chalk": "^5.6",
+        "yaml": "^2.4.0",
       },
     },
     "packages/natives": {

--- a/packages/fixbot/package.json
+++ b/packages/fixbot/package.json
@@ -24,7 +24,8 @@
 		"@oh-my-pi/pi-ai": "workspace:*",
 		"@oh-my-pi/pi-coding-agent": "workspace:*",
 		"@oh-my-pi/pi-utils": "workspace:*",
-		"chalk": "^5.6"
+		"chalk": "^5.6",
+		"yaml": "^2.4.0"
 	},
 	"scripts": {
 		"test": "bun test"

--- a/packages/fixbot/src/execution.ts
+++ b/packages/fixbot/src/execution.ts
@@ -11,6 +11,7 @@ export interface PreparedJobContext {
 	baseCommit: string;
 	hostConfig: HostAgentConfig;
 	selectedModel: ModelSelection;
+	repoExcludePaths?: string[];
 }
 
 export interface PreparedJobExecutor {

--- a/packages/fixbot/src/internal-runner.ts
+++ b/packages/fixbot/src/internal-runner.ts
@@ -140,7 +140,7 @@ export function getConfiguredAuthFilePath(): string | undefined {
 	return hostConfig.authFileExists ? hostConfig.authFilePath : undefined;
 }
 
-export function buildInjectedContext(job: NormalizedJobSpecV1, selectedModel: ModelSelection): string {
+export function buildInjectedContext(job: NormalizedJobSpecV1, selectedModel: ModelSelection, repoExcludePaths?: string[]): string {
 	const modelLine = job.execution.model
 		? `${job.execution.model.provider}/${job.execution.model.modelId}`
 		: "default model selection";
@@ -213,6 +213,16 @@ export function buildInjectedContext(job: NormalizedJobSpecV1, selectedModel: Mo
 		"- Do not ask the user for follow-up input.",
 		"- If blocked, return `FIXBOT_RESULT: failed` with a precise reason.",
 	);
+
+	if (repoExcludePaths && repoExcludePaths.length > 0) {
+		sharedLines.push(
+			"",
+			"## Excluded Paths",
+			"",
+			"Do not read or modify files matching these patterns:",
+			...repoExcludePaths.map((p) => `- \`${p}\``),
+		);
+	}
 
 	return sharedLines.join("\n");
 }
@@ -557,7 +567,7 @@ export async function runInternalExecutionFromPlan(
 	if (!existsSync(assistantFinalFile)) {
 		writeFileSync(assistantFinalFile, "", "utf-8");
 	}
-	writeFileSync(injectedContextFile, buildInjectedContext(plan.job, plan.selectedModel), "utf-8");
+	writeFileSync(injectedContextFile, buildInjectedContext(plan.job, plan.selectedModel, plan.repoExcludePaths), "utf-8");
 
 	try {
 		const prompt = buildGitFixPrompt(plan.job);

--- a/packages/fixbot/src/repo-config.ts
+++ b/packages/fixbot/src/repo-config.ts
@@ -1,0 +1,202 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { Logger } from "./logger";
+import type { DaemonModelConfig, RepoConfig, RepoModelConfig } from "./types";
+
+/** Path within a repo checkout where the per-repo config lives. */
+export const REPO_CONFIG_PATH = ".fixbot/config.yml";
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a "provider/modelId" string into a {@link RepoModelConfig}.
+ * Returns `undefined` if the format is invalid.
+ */
+export function parseModelString(raw: unknown): RepoModelConfig | undefined {
+	if (typeof raw !== "string") return undefined;
+	const trimmed = raw.trim();
+	const slashIndex = trimmed.indexOf("/");
+	if (slashIndex <= 0 || slashIndex === trimmed.length - 1) return undefined;
+	return {
+		provider: trimmed.slice(0, slashIndex),
+		modelId: trimmed.slice(slashIndex + 1),
+	};
+}
+
+/**
+ * Parse raw YAML text into a validated {@link RepoConfig}.
+ *
+ * - Unknown top-level keys produce warnings but don't fail.
+ * - Invalid `model` or `excludePaths` values produce warnings and are dropped.
+ * - Returns `{ config, warnings }`.
+ */
+export function parseRepoConfig(yamlText: string): { config: RepoConfig; warnings: string[] } {
+	const warnings: string[] = [];
+	const config: RepoConfig = {};
+
+	let raw: unknown;
+	try {
+		raw = parseYaml(yamlText);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		warnings.push(`Invalid YAML: ${msg}`);
+		return { config, warnings };
+	}
+
+	if (raw === null || raw === undefined) {
+		return { config, warnings };
+	}
+
+	if (typeof raw !== "object" || Array.isArray(raw)) {
+		warnings.push("Config must be a YAML mapping (object), got " + (Array.isArray(raw) ? "array" : typeof raw));
+		return { config, warnings };
+	}
+
+	const record = raw as Record<string, unknown>;
+	const knownKeys = new Set(["model", "excludePaths"]);
+
+	for (const key of Object.keys(record)) {
+		if (!knownKeys.has(key)) {
+			warnings.push(`Unknown config key "${key}" — ignoring`);
+		}
+	}
+
+	// model
+	if ("model" in record && record.model !== undefined && record.model !== null) {
+		const parsed = parseModelString(record.model);
+		if (parsed) {
+			config.model = parsed;
+		} else {
+			warnings.push(
+				`Invalid model value "${String(record.model)}" — expected "provider/modelId" format (e.g. "anthropic/claude-sonnet-4-6")`,
+			);
+		}
+	}
+
+	// excludePaths
+	if ("excludePaths" in record && record.excludePaths !== undefined && record.excludePaths !== null) {
+		if (Array.isArray(record.excludePaths)) {
+			const valid: string[] = [];
+			for (const item of record.excludePaths) {
+				if (typeof item === "string" && item.trim() !== "") {
+					valid.push(item.trim());
+				} else {
+					warnings.push(`Invalid excludePaths entry ${JSON.stringify(item)} — must be a non-empty string`);
+				}
+			}
+			if (valid.length > 0) {
+				config.excludePaths = valid;
+			}
+		} else {
+			warnings.push("excludePaths must be an array of glob strings");
+		}
+	}
+
+	return { config, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and parse `.fixbot/config.yml` from a workspace directory.
+ *
+ * - If the file doesn't exist, returns an empty config with no warnings.
+ * - If the file can't be read or parsed, returns an empty config with warnings.
+ * - Never throws.
+ */
+export function loadRepoConfig(
+	workspaceDir: string,
+	logger?: Logger,
+): { config: RepoConfig; warnings: string[] } {
+	const configPath = join(workspaceDir, REPO_CONFIG_PATH);
+
+	if (!existsSync(configPath)) {
+		return { config: {}, warnings: [] };
+	}
+
+	let yamlText: string;
+	try {
+		yamlText = readFileSync(configPath, "utf-8");
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		const warning = `Failed to read ${REPO_CONFIG_PATH}: ${msg}`;
+		logger?.warn(warning);
+		return { config: {}, warnings: [warning] };
+	}
+
+	const result = parseRepoConfig(yamlText);
+
+	for (const w of result.warnings) {
+		logger?.warn(`${REPO_CONFIG_PATH}: ${w}`);
+	}
+
+	if (result.config.model) {
+		logger?.info(
+			`repo config: model=${result.config.model.provider}/${result.config.model.modelId}`,
+		);
+	}
+	if (result.config.excludePaths && result.config.excludePaths.length > 0) {
+		logger?.info(`repo config: excludePaths=[${result.config.excludePaths.join(", ")}]`);
+	}
+
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Merging
+// ---------------------------------------------------------------------------
+
+export interface MergedConfig {
+	/** The resolved model config — repo wins over daemon. */
+	model?: DaemonModelConfig;
+	/** Source of the model: "repo", "daemon", or undefined if no model set. */
+	modelSource?: "repo" | "daemon";
+	/** Merged excludePaths from repo config (daemon has no equivalent). */
+	excludePaths?: string[];
+}
+
+/**
+ * Merge per-repo config with daemon-level config.
+ *
+ * Priority: repo config wins over daemon config for overlapping fields.
+ * Logs which values came from which source.
+ */
+export function mergeConfigs(
+	repoConfig: RepoConfig,
+	daemonModel: DaemonModelConfig | undefined,
+	logger?: Logger,
+): MergedConfig {
+	const result: MergedConfig = {};
+
+	if (repoConfig.model) {
+		result.model = {
+			provider: repoConfig.model.provider,
+			modelId: repoConfig.model.modelId,
+		};
+		result.modelSource = "repo";
+		if (daemonModel) {
+			logger?.info(
+				`model from repo config (${repoConfig.model.provider}/${repoConfig.model.modelId}) overrides daemon config (${daemonModel.provider}/${daemonModel.modelId})`,
+			);
+		} else {
+			logger?.info(
+				`model from repo config: ${repoConfig.model.provider}/${repoConfig.model.modelId}`,
+			);
+		}
+	} else if (daemonModel) {
+		result.model = daemonModel;
+		result.modelSource = "daemon";
+		logger?.info(`model from daemon config: ${daemonModel.provider}/${daemonModel.modelId}`);
+	}
+
+	if (repoConfig.excludePaths && repoConfig.excludePaths.length > 0) {
+		result.excludePaths = repoConfig.excludePaths;
+	}
+
+	return result;
+}

--- a/packages/fixbot/src/runner.ts
+++ b/packages/fixbot/src/runner.ts
@@ -23,6 +23,7 @@ import { resolveExecutionModel, resolveHostAgentConfig } from "./host-agent";
 import { assertDockerImageReady } from "./image";
 import { createStderrLogger, type Logger } from "./logger";
 import { deriveResultStatus, parseResultMarkers } from "./markers";
+import { loadRepoConfig, mergeConfigs } from "./repo-config";
 import {
 	EXECUTION_PLAN_VERSION_V1,
 	type ExecutionOutputV1,
@@ -69,13 +70,18 @@ function buildExecutionPlan(
 	job: NormalizedJobSpecV1,
 	baseCommit: string,
 	selectedModel: ModelSelection,
+	repoExcludePaths?: string[],
 ): ExecutionPlanV1 {
-	return {
+	const plan: ExecutionPlanV1 = {
 		version: EXECUTION_PLAN_VERSION_V1,
 		job,
 		baseCommit,
 		selectedModel,
 	};
+	if (repoExcludePaths && repoExcludePaths.length > 0) {
+		plan.repoExcludePaths = repoExcludePaths;
+	}
+	return plan;
 }
 
 /** Format milliseconds as a human-readable duration, e.g. "2m 18s" or "45s". */
@@ -152,22 +158,30 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 
 	try {
 		const hostConfig = resolveHostAgentConfig();
-		const resolvedModel = await resolveExecutionModel(job, { configModel: options.configModel });
-		selectedModel = {
-			provider: resolvedModel.provider,
-			modelId: resolvedModel.id,
-		};
-		log.info(`preflight selected model ${resolvedModel.provider}/${resolvedModel.id}`);
 		if (job.execution.mode === "docker") {
 			assertDockerGithubAuth();
 			await dockerImageVerifier();
 		}
+
 		log.info(`cloning ${job.repo.url} @ ${job.repo.baseBranch}`);
 		await cloneRepository(job.repo.url, job.repo.baseBranch, paths.workspaceDir);
 		await configureLocalGitIdentity(paths.workspaceDir);
 		baseCommit = await getHeadCommit(paths.workspaceDir);
-		log.info(`repository cloned at ${baseCommit}`);
-		writeJson(paths.executionPlanFile, buildExecutionPlan(job, baseCommit, selectedModel));
+		log.info(`repository ready at ${baseCommit}`);
+
+		// Load per-repo .fixbot/config.yml and merge with daemon config
+		const { config: repoConfig } = loadRepoConfig(paths.workspaceDir, log);
+		const merged = mergeConfigs(repoConfig, options.configModel, log);
+
+		const resolvedModel = await resolveExecutionModel(job, {
+			configModel: merged.model,
+		});
+		selectedModel = {
+			provider: resolvedModel.provider,
+			modelId: resolvedModel.id,
+		};
+		log.info(`selected model ${resolvedModel.provider}/${resolvedModel.id} (source: ${merged.modelSource ?? "default"})`);
+		writeJson(paths.executionPlanFile, buildExecutionPlan(job, baseCommit, selectedModel, merged.excludePaths));
 
 		const context: PreparedJobContext = {
 			job,
@@ -175,6 +189,7 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 			baseCommit,
 			hostConfig,
 			selectedModel,
+			repoExcludePaths: merged.excludePaths,
 		};
 		log.info("agent running");
 		executionOutput = await executor.execute(context);

--- a/packages/fixbot/src/types.ts
+++ b/packages/fixbot/src/types.ts
@@ -117,6 +117,7 @@ export interface ExecutionPlanV1 {
 	job: NormalizedJobSpecV1;
 	baseCommit: string;
 	selectedModel: ModelSelection;
+	repoExcludePaths?: string[];
 }
 
 export interface ModelSelection {
@@ -392,4 +393,18 @@ export interface DaemonStatusSnapshotV1 {
 	queue: DaemonQueueStatusV1;
 	activeJob: DaemonActiveJobStatusV1 | null;
 	recentResults: DaemonRecentResultSummaryV1[];
+}
+
+// ---------------------------------------------------------------------------
+// Per-repo configuration types
+// ---------------------------------------------------------------------------
+
+export interface RepoModelConfig {
+	provider: string;
+	modelId: string;
+}
+
+export interface RepoConfig {
+	model?: RepoModelConfig;
+	excludePaths?: string[];
 }

--- a/packages/fixbot/test/internal-runner.test.ts
+++ b/packages/fixbot/test/internal-runner.test.ts
@@ -505,6 +505,66 @@ describe("internal runner", () => {
 		expect(ctx).not.toContain("GitHub Actions Run ID");
 	});
 
+	it("buildInjectedContext includes Excluded Paths section when repoExcludePaths provided", () => {
+		const job: NormalizedJobSpecV1 = {
+			version: "fixbot.job/v1",
+			jobId: "exclude-ctx-1",
+			taskClass: "fix_lint",
+			repo: { url: "https://example.com/repo.git", baseBranch: "main" },
+			fixLint: { lintCommand: "eslint ." },
+			execution: {
+				mode: "process",
+				timeoutMs: 300000,
+				memoryLimitMb: 4096,
+				sandbox: { mode: "workspace-write", networkAccess: true },
+			},
+		};
+		const ctx = buildInjectedContext(job, { provider: "anthropic", modelId: "claude-sonnet-4-5" }, [
+			"vendor/**",
+			"dist/**",
+		]);
+		expect(ctx).toContain("## Excluded Paths");
+		expect(ctx).toContain("Do not read or modify files matching these patterns:");
+		expect(ctx).toContain("- `vendor/**`");
+		expect(ctx).toContain("- `dist/**`");
+	});
+
+	it("buildInjectedContext omits Excluded Paths section when repoExcludePaths is empty", () => {
+		const job: NormalizedJobSpecV1 = {
+			version: "fixbot.job/v1",
+			jobId: "exclude-ctx-2",
+			taskClass: "fix_lint",
+			repo: { url: "https://example.com/repo.git", baseBranch: "main" },
+			fixLint: { lintCommand: "eslint ." },
+			execution: {
+				mode: "process",
+				timeoutMs: 300000,
+				memoryLimitMb: 4096,
+				sandbox: { mode: "workspace-write", networkAccess: true },
+			},
+		};
+		const ctx = buildInjectedContext(job, { provider: "anthropic", modelId: "claude-sonnet-4-5" }, []);
+		expect(ctx).not.toContain("## Excluded Paths");
+	});
+
+	it("buildInjectedContext omits Excluded Paths section when repoExcludePaths is undefined", () => {
+		const job: NormalizedJobSpecV1 = {
+			version: "fixbot.job/v1",
+			jobId: "exclude-ctx-3",
+			taskClass: "fix_lint",
+			repo: { url: "https://example.com/repo.git", baseBranch: "main" },
+			fixLint: { lintCommand: "eslint ." },
+			execution: {
+				mode: "process",
+				timeoutMs: 300000,
+				memoryLimitMb: 4096,
+				sandbox: { mode: "workspace-write", networkAccess: true },
+			},
+		};
+		const ctx = buildInjectedContext(job, { provider: "anthropic", modelId: "claude-sonnet-4-5" });
+		expect(ctx).not.toContain("## Excluded Paths");
+	});
+
 	it("mock session driver receives correct prompt for fix_lint plan", async () => {
 		const artifactDir = join(tmpdir(), `fixbot-lint-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(join(artifactDir, "workspace"), { recursive: true });

--- a/packages/fixbot/test/repo-config.test.ts
+++ b/packages/fixbot/test/repo-config.test.ts
@@ -1,0 +1,369 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { createCapturingLogger } from "../src/logger";
+import {
+	loadRepoConfig,
+	mergeConfigs,
+	parseModelString,
+	parseRepoConfig,
+	REPO_CONFIG_PATH,
+} from "../src/repo-config";
+import type { DaemonModelConfig, RepoConfig } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// parseModelString
+// ---------------------------------------------------------------------------
+
+describe("parseModelString", () => {
+	it("parses a valid provider/modelId string", () => {
+		expect(parseModelString("anthropic/claude-sonnet-4-6")).toEqual({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+		});
+	});
+
+	it("handles whitespace around the string", () => {
+		expect(parseModelString("  openai/gpt-4o  ")).toEqual({
+			provider: "openai",
+			modelId: "gpt-4o",
+		});
+	});
+
+	it("returns undefined for non-string input", () => {
+		expect(parseModelString(123)).toBeUndefined();
+		expect(parseModelString(null)).toBeUndefined();
+		expect(parseModelString(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined for string without slash", () => {
+		expect(parseModelString("claude-sonnet-4-6")).toBeUndefined();
+	});
+
+	it("returns undefined for string with only leading slash", () => {
+		expect(parseModelString("/claude-sonnet-4-6")).toBeUndefined();
+	});
+
+	it("returns undefined for string with only trailing slash", () => {
+		expect(parseModelString("anthropic/")).toBeUndefined();
+	});
+
+	it("handles model IDs with multiple slashes", () => {
+		expect(parseModelString("provider/org/model-name")).toEqual({
+			provider: "provider",
+			modelId: "org/model-name",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseRepoConfig
+// ---------------------------------------------------------------------------
+
+describe("parseRepoConfig", () => {
+	it("parses a valid full config", () => {
+		const yaml = `
+model: anthropic/claude-sonnet-4-6
+excludePaths:
+  - "vendor/**"
+  - "generated/**"
+  - "*.lock"
+`;
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings).toEqual([]);
+		expect(config.model).toEqual({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+		});
+		expect(config.excludePaths).toEqual(["vendor/**", "generated/**", "*.lock"]);
+	});
+
+	it("returns empty config for empty YAML", () => {
+		const { config, warnings } = parseRepoConfig("");
+		expect(warnings).toEqual([]);
+		expect(config).toEqual({});
+	});
+
+	it("returns empty config for null YAML document", () => {
+		const { config, warnings } = parseRepoConfig("null");
+		expect(warnings).toEqual([]);
+		expect(config).toEqual({});
+	});
+
+	it("warns on invalid YAML syntax", () => {
+		const { config, warnings } = parseRepoConfig("model:\n  - :\n  bad: [unterminated");
+		expect(warnings.length).toBeGreaterThan(0);
+		expect(warnings[0]).toContain("Invalid YAML");
+		expect(config).toEqual({});
+	});
+
+	it("warns when config is an array instead of object", () => {
+		const { config, warnings } = parseRepoConfig("- item1\n- item2");
+		expect(warnings).toEqual(["Config must be a YAML mapping (object), got array"]);
+		expect(config).toEqual({});
+	});
+
+	it("warns on unknown keys but still parses known keys", () => {
+		const yaml = `
+model: anthropic/claude-sonnet-4-6
+unknownKey: value
+anotherUnknown: 42
+`;
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings).toContainEqual('Unknown config key "unknownKey" — ignoring');
+		expect(warnings).toContainEqual('Unknown config key "anotherUnknown" — ignoring');
+		expect(config.model).toEqual({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+		});
+	});
+
+	it("warns on invalid model format", () => {
+		const yaml = "model: just-a-model-name";
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain("Invalid model value");
+		expect(config.model).toBeUndefined();
+	});
+
+	it("warns on non-array excludePaths", () => {
+		const yaml = "excludePaths: vendor/**";
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings).toEqual(["excludePaths must be an array of glob strings"]);
+		expect(config.excludePaths).toBeUndefined();
+	});
+
+	it("filters invalid entries from excludePaths array", () => {
+		const yaml = `
+excludePaths:
+  - "vendor/**"
+  - 123
+  - ""
+  - "*.lock"
+`;
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(config.excludePaths).toEqual(["vendor/**", "*.lock"]);
+		expect(warnings.length).toBe(2);
+	});
+
+	it("parses config with only model", () => {
+		const yaml = "model: openai/gpt-4o";
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings).toEqual([]);
+		expect(config.model).toEqual({ provider: "openai", modelId: "gpt-4o" });
+		expect(config.excludePaths).toBeUndefined();
+	});
+
+	it("parses config with only excludePaths", () => {
+		const yaml = 'excludePaths:\n  - "dist/**"';
+		const { config, warnings } = parseRepoConfig(yaml);
+		expect(warnings).toEqual([]);
+		expect(config.model).toBeUndefined();
+		expect(config.excludePaths).toEqual(["dist/**"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadRepoConfig
+// ---------------------------------------------------------------------------
+
+describe("loadRepoConfig", () => {
+	let tmpDir: string;
+
+	function makeTmpDir(): string {
+		const dir = join(tmpdir(), `fixbot-repo-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	afterEach(() => {
+		if (tmpDir) {
+			try {
+				rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	});
+
+	it("returns empty config when .fixbot/config.yml does not exist", () => {
+		tmpDir = makeTmpDir();
+		const { config, warnings } = loadRepoConfig(tmpDir);
+		expect(config).toEqual({});
+		expect(warnings).toEqual([]);
+	});
+
+	it("loads and parses a valid config file", () => {
+		tmpDir = makeTmpDir();
+		const configDir = join(tmpDir, ".fixbot");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.yml"),
+			'model: anthropic/claude-sonnet-4-6\nexcludePaths:\n  - "vendor/**"\n',
+			"utf-8",
+		);
+
+		const logger = createCapturingLogger();
+		const { config, warnings } = loadRepoConfig(tmpDir, logger);
+		expect(warnings).toEqual([]);
+		expect(config.model).toEqual({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+		});
+		expect(config.excludePaths).toEqual(["vendor/**"]);
+		// Logger should have recorded the config values
+		expect(logger.lines.some((l) => l.includes("repo config: model="))).toBe(true);
+	});
+
+	it("returns warnings for invalid YAML content", () => {
+		tmpDir = makeTmpDir();
+		const configDir = join(tmpDir, ".fixbot");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.yml"), ":::bad:::", "utf-8");
+
+		const logger = createCapturingLogger();
+		const { config, warnings } = loadRepoConfig(tmpDir, logger);
+		expect(config).toEqual({});
+		expect(warnings.length).toBeGreaterThan(0);
+		expect(logger.lines.some((l) => l.includes("[WARN]"))).toBe(true);
+	});
+
+	it("returns empty config when config file is empty", () => {
+		tmpDir = makeTmpDir();
+		const configDir = join(tmpDir, ".fixbot");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.yml"), "", "utf-8");
+
+		const { config, warnings } = loadRepoConfig(tmpDir);
+		expect(config).toEqual({});
+		expect(warnings).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mergeConfigs
+// ---------------------------------------------------------------------------
+
+describe("mergeConfigs", () => {
+	it("returns empty result when neither repo nor daemon has config", () => {
+		const result = mergeConfigs({}, undefined);
+		expect(result).toEqual({});
+	});
+
+	it("uses daemon model when repo has none", () => {
+		const daemonModel: DaemonModelConfig = { provider: "anthropic", modelId: "claude-sonnet-4-6" };
+		const logger = createCapturingLogger();
+		const result = mergeConfigs({}, daemonModel, logger);
+		expect(result.model).toEqual(daemonModel);
+		expect(result.modelSource).toBe("daemon");
+		expect(logger.lines.some((l) => l.includes("daemon config"))).toBe(true);
+	});
+
+	it("uses repo model when daemon has none", () => {
+		const repoConfig: RepoConfig = {
+			model: { provider: "openai", modelId: "gpt-4o" },
+		};
+		const logger = createCapturingLogger();
+		const result = mergeConfigs(repoConfig, undefined, logger);
+		expect(result.model).toEqual({ provider: "openai", modelId: "gpt-4o" });
+		expect(result.modelSource).toBe("repo");
+		expect(logger.lines.some((l) => l.includes("repo config"))).toBe(true);
+	});
+
+	it("repo model overrides daemon model", () => {
+		const repoConfig: RepoConfig = {
+			model: { provider: "openai", modelId: "gpt-4o" },
+		};
+		const daemonModel: DaemonModelConfig = { provider: "anthropic", modelId: "claude-sonnet-4-6" };
+		const logger = createCapturingLogger();
+		const result = mergeConfigs(repoConfig, daemonModel, logger);
+		expect(result.model).toEqual({ provider: "openai", modelId: "gpt-4o" });
+		expect(result.modelSource).toBe("repo");
+		expect(logger.lines.some((l) => l.includes("overrides daemon"))).toBe(true);
+	});
+
+	it("passes through excludePaths from repo config", () => {
+		const repoConfig: RepoConfig = {
+			excludePaths: ["vendor/**", "*.lock"],
+		};
+		const result = mergeConfigs(repoConfig, undefined);
+		expect(result.excludePaths).toEqual(["vendor/**", "*.lock"]);
+	});
+
+	it("does not include empty excludePaths", () => {
+		const repoConfig: RepoConfig = {
+			excludePaths: [],
+		};
+		const result = mergeConfigs(repoConfig, undefined);
+		expect(result.excludePaths).toBeUndefined();
+	});
+
+	it("merges model and excludePaths together", () => {
+		const repoConfig: RepoConfig = {
+			model: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+			excludePaths: ["dist/**"],
+		};
+		const daemonModel: DaemonModelConfig = { provider: "openai", modelId: "gpt-4o" };
+		const result = mergeConfigs(repoConfig, daemonModel);
+		expect(result.model).toEqual({ provider: "anthropic", modelId: "claude-sonnet-4-6" });
+		expect(result.modelSource).toBe("repo");
+		expect(result.excludePaths).toEqual(["dist/**"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration: end-to-end load + merge
+// ---------------------------------------------------------------------------
+
+describe("integration", () => {
+	let tmpDir: string;
+
+	function makeTmpDir(): string {
+		const dir = join(tmpdir(), `fixbot-repo-config-int-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(dir, { recursive: true });
+		return dir;
+	}
+
+	afterEach(() => {
+		if (tmpDir) {
+			try {
+				rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				// best-effort cleanup
+			}
+		}
+	});
+
+	it("load + merge: repo model overrides daemon model end-to-end", () => {
+		tmpDir = makeTmpDir();
+		const configDir = join(tmpDir, ".fixbot");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.yml"),
+			'model: openai/gpt-4o\nexcludePaths:\n  - "vendor/**"\n  - "*.lock"\n',
+			"utf-8",
+		);
+
+		const logger = createCapturingLogger();
+		const { config: repoConfig } = loadRepoConfig(tmpDir, logger);
+		const daemonModel: DaemonModelConfig = { provider: "anthropic", modelId: "claude-sonnet-4-6" };
+		const merged = mergeConfigs(repoConfig, daemonModel, logger);
+
+		expect(merged.model).toEqual({ provider: "openai", modelId: "gpt-4o" });
+		expect(merged.modelSource).toBe("repo");
+		expect(merged.excludePaths).toEqual(["vendor/**", "*.lock"]);
+	});
+
+	it("load + merge: falls back to daemon model when no repo config exists", () => {
+		tmpDir = makeTmpDir();
+		const logger = createCapturingLogger();
+		const { config: repoConfig } = loadRepoConfig(tmpDir, logger);
+		const daemonModel: DaemonModelConfig = { provider: "anthropic", modelId: "claude-sonnet-4-6" };
+		const merged = mergeConfigs(repoConfig, daemonModel, logger);
+
+		expect(merged.model).toEqual(daemonModel);
+		expect(merged.modelSource).toBe("daemon");
+		expect(merged.excludePaths).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds per-repo `.fixbot/config.yml` support for overriding model (`provider/modelId`) and specifying `excludePaths` glob patterns the agent should not touch
- Runner loads repo config after clone, merges with daemon config (repo wins for model selection), and propagates `repoExcludePaths` through execution plan and injected context
- 31 tests covering YAML parsing, validation, loading, merging, and end-to-end integration

Closes #20

## Test plan

- [x] `bun test test/repo-config.test.ts` — 31 tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: add `.fixbot/config.yml` to a test repo, verify model override and excludePaths appear in execution plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)