### PR TITLE
feat: repository cache with bare clones and git worktrees

### DIFF
--- a/packages/fixbot/src/config.ts
+++ b/packages/fixbot/src/config.ts
@@ -19,10 +19,12 @@ import {
 	type NormalizedDaemonConfigV1,
 	type NormalizedDaemonGitHubConfig,
 	type NormalizedDaemonGitHubRepoConfig,
+	type RepoCacheConfig,
 	type ResultStatus,
 	TASK_CLASSES,
 	type TaskClass,
 } from "./types";
+import { DEFAULT_REPO_CACHE_CONFIG } from "./repo-cache";
 import {
 	assertBoolean,
 	assertNonEmptyString,
@@ -278,6 +280,29 @@ function normalizeGitHubConfig(raw: unknown, label: string): NormalizedDaemonGit
 	};
 }
 
+function normalizeRepoCacheConfig(raw: unknown, label: string): RepoCacheConfig {
+	const obj = assertObject(raw, label);
+	const enabled =
+		obj.enabled === undefined ? DEFAULT_REPO_CACHE_CONFIG.enabled : assertBoolean(obj.enabled, `${label}.enabled`);
+	const dir =
+		obj.dir === undefined
+			? DEFAULT_REPO_CACHE_CONFIG.dir
+			: assertNonEmptyString(obj.dir, `${label}.dir`).replace(/^~(?=\/)/, homedir());
+	const maxRepos =
+		obj.maxRepos === undefined
+			? DEFAULT_REPO_CACHE_CONFIG.maxRepos
+			: assertPositiveInteger(obj.maxRepos, `${label}.maxRepos`);
+	const maxDiskMb =
+		obj.maxDiskMb === undefined
+			? DEFAULT_REPO_CACHE_CONFIG.maxDiskMb
+			: assertPositiveInteger(obj.maxDiskMb, `${label}.maxDiskMb`);
+	const staleBranchDays =
+		obj.staleBranchDays === undefined
+			? DEFAULT_REPO_CACHE_CONFIG.staleBranchDays
+			: assertPositiveInteger(obj.staleBranchDays, `${label}.staleBranchDays`);
+	return { enabled, dir, maxRepos, maxDiskMb, staleBranchDays };
+}
+
 export function normalizeDaemonConfig(value: unknown, source: string = "daemon config"): NormalizedDaemonConfigV1 {
 	const root = assertObject(value, source);
 	if (root.version !== DAEMON_CONFIG_VERSION_V1) {
@@ -343,6 +368,10 @@ export function normalizeDaemonConfig(value: unknown, source: string = "daemon c
 		github,
 		identity: { botUrl },
 		model,
+		repoCache:
+			root.repoCache === undefined
+				? undefined
+				: normalizeRepoCacheConfig(root.repoCache, `${source}.repoCache`),
 	};
 }
 

--- a/packages/fixbot/src/daemon/service.ts
+++ b/packages/fixbot/src/daemon/service.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import { createDaemonStatus, loadDaemonConfig } from "../config";
 import { type Logger, toLogCallback } from "../logger";
 import { runJob } from "../runner";
+import { cleanupWorktree, deriveRepoCacheKey } from "../repo-cache";
 import type {
 	DaemonErrorSummary,
 	DaemonJobEnvelopeV1,
@@ -12,6 +13,7 @@ import type {
 	JobResultV1,
 	NormalizedDaemonConfigV1,
 	NormalizedJobSpecV1,
+	RepoCacheConfig,
 } from "../types";
 import { exchangeInstallationToken, isTokenExpiringSoon, type TokenCache } from "./github-app-auth";
 import type { GitHubPollResult } from "./github-poller";
@@ -61,6 +63,7 @@ export interface DaemonJobRunnerOptions {
 	resultsDir: string;
 	configModel?: import("../types").DaemonModelConfig;
 	logger?: Logger;
+	repoCacheConfig?: RepoCacheConfig;
 }
 
 export type DaemonJobRunner = (job: NormalizedJobSpecV1, options: DaemonJobRunnerOptions) => Promise<JobResultV1>;
@@ -401,6 +404,7 @@ async function runClaimedDaemonJob(
 			resultsDir: config.paths.resultsDir,
 			configModel: config.model,
 			logger,
+			repoCacheConfig: config.repoCache,
 		});
 		removeActiveDaemonJob(config, claimed.envelope.jobId);
 		const recentResults = appendRecentResult(
@@ -470,6 +474,20 @@ async function runClaimedDaemonJob(
 		);
 	} finally {
 		clearInterval(heartbeatTimer);
+
+		// Clean up worktree if repo-cache was used.
+		if (config.repoCache?.enabled) {
+			try {
+				const { owner, repo } = deriveRepoCacheKey(claimed.envelope.job.repo.url);
+				const { join } = await import("node:path");
+				const bareDir = join(config.repoCache.dir, owner, `${repo}.git`);
+				await cleanupWorktree(bareDir, claimed.envelope.jobId, logger ? (msg) => logger.info(msg) : undefined);
+			} catch (cleanupErr) {
+				logger?.warn(
+					`repo-cache: worktree cleanup failed for job ${claimed.envelope.jobId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+				);
+			}
+		}
 	}
 }
 

--- a/packages/fixbot/src/git.ts
+++ b/packages/fixbot/src/git.ts
@@ -115,6 +115,91 @@ export async function countCommittedChangedFiles(workspaceDir: string, baseCommi
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Bare-clone / worktree helpers (repo-cache)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a bare clone of a repository.
+ * A bare clone contains only the .git directory objects and refs — no working tree.
+ * This is the long-lived cache object that worktrees are created from.
+ */
+export async function bareCloneRepo(url: string, bareDir: string): Promise<void> {
+	await spawnCommandOrThrow("git", ["clone", "--bare", url, bareDir]);
+}
+
+/**
+ * After a bare clone, `remote.origin.fetch` is unset because there is no
+ * default refspec in bare repos.  Configure it so that `git fetch` pulls
+ * all remote branches into `refs/remotes/origin/*`.
+ */
+export async function configureBareFetchRefspec(bareDir: string): Promise<void> {
+	await spawnCommandOrThrow(
+		"git",
+		["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"],
+		{ cwd: bareDir },
+	);
+}
+
+/**
+ * Fetch a specific branch (or all branches when `branch` is `"*"`)
+ * inside a bare repository.
+ */
+export async function fetchBranch(bareDir: string, branch: string): Promise<void> {
+	if (branch === "*") {
+		await spawnCommandOrThrow("git", ["fetch", "origin"], { cwd: bareDir });
+	} else {
+		await spawnCommandOrThrow("git", ["fetch", "origin", branch], { cwd: bareDir });
+	}
+}
+
+/**
+ * Add a new worktree checked out at `origin/{baseBranch}` on a new
+ * local branch `localBranch`.
+ */
+export async function addWorktree(
+	bareDir: string,
+	worktreeDir: string,
+	localBranch: string,
+	baseBranch: string,
+): Promise<void> {
+	await spawnCommandOrThrow(
+		"git",
+		["worktree", "add", worktreeDir, "-b", localBranch, `origin/${baseBranch}`],
+		{ cwd: bareDir },
+	);
+}
+
+/**
+ * Remove a worktree and delete its local branch.
+ * Non-fatal: logs a warning when the worktree directory has already been deleted.
+ */
+export async function removeWorktree(
+	bareDir: string,
+	worktreeDir: string,
+	localBranch: string,
+	logger?: (message: string) => void,
+): Promise<void> {
+	try {
+		await spawnCommandOrThrow("git", ["worktree", "remove", "--force", worktreeDir], { cwd: bareDir });
+	} catch (err) {
+		logger?.(`[fixbot] git: worktree remove failed for ${worktreeDir}: ${err instanceof Error ? err.message : String(err)}`);
+	}
+	try {
+		await spawnCommandOrThrow("git", ["branch", "-D", localBranch], { cwd: bareDir });
+	} catch {
+		// Branch may not exist if worktree creation failed partway.
+	}
+}
+
+/**
+ * Prune stale worktree bookkeeping entries that point to directories
+ * that no longer exist on disk.
+ */
+export async function pruneWorktrees(bareDir: string): Promise<void> {
+	await spawnCommandOrThrow("git", ["worktree", "prune"], { cwd: bareDir });
+}
+
 export function copyOptionalWorkspaceArtifact(
 	workspaceDir: string,
 	relativePath: string,

--- a/packages/fixbot/src/github-utils.ts
+++ b/packages/fixbot/src/github-utils.ts
@@ -9,9 +9,26 @@
 /**
  * Extract owner/repo from a GitHub URL like `https://github.com/owner/repo`
  * or `https://github.com/owner/repo.git`, or from an `owner/repo` shorthand.
+ *
+ * Supported formats:
+ * - HTTPS URLs:  `https://github.com/owner/repo[.git]`
+ * - HTTP URLs:   `http://github.com/owner/repo[.git]`
+ * - SSH URLs:    `git@github.com:owner/repo[.git]`
+ * - Shorthand:   `owner/repo`
  */
 export function parseOwnerRepo(input: string): { owner: string; repo: string } {
-	// If it looks like a URL, parse it
+	// SSH URL format: git@github.com:owner/repo.git
+	const sshMatch = input.match(/^git@[^:]+:(.+)$/);
+	if (sshMatch) {
+		const path = sshMatch[1].replace(/\.git$/, "").replace(/\/$/, "");
+		const segments = path.split("/").filter(Boolean);
+		if (segments.length !== 2) {
+			throw new Error(`GitHub SSH URL must have exactly owner/repo path segments: ${input}`);
+		}
+		return { owner: segments[0], repo: segments[1] };
+	}
+
+	// HTTPS / HTTP URL format
 	if (input.startsWith("http://") || input.startsWith("https://")) {
 		let pathname: string;
 		try {
@@ -30,7 +47,7 @@ export function parseOwnerRepo(input: string): { owner: string; repo: string } {
 		return { owner: segments[0], repo: segments[1] };
 	}
 
-	// Otherwise treat as owner/repo shorthand
+	// Plain owner/repo shorthand (no protocol, no colon)
 	const cleaned = input.replace(/\.git$/, "").replace(/\/$/, "");
 	const segments = cleaned.split("/").filter(Boolean);
 	if (segments.length !== 2) {

--- a/packages/fixbot/src/github-utils.ts
+++ b/packages/fixbot/src/github-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared GitHub URL utilities.
+ *
+ * `parseOwnerRepo` was originally defined in `daemon/github-reporter.ts`.
+ * It is now re-exported from this module so that both the reporter and the
+ * repo-cache can use it without circular dependencies.
+ */
+
+/**
+ * Extract owner/repo from a GitHub URL like `https://github.com/owner/repo`
+ * or `https://github.com/owner/repo.git`, or from an `owner/repo` shorthand.
+ */
+export function parseOwnerRepo(input: string): { owner: string; repo: string } {
+	// If it looks like a URL, parse it
+	if (input.startsWith("http://") || input.startsWith("https://")) {
+		let pathname: string;
+		try {
+			pathname = new URL(input).pathname;
+		} catch {
+			throw new Error(`Invalid GitHub repo URL: ${input}`);
+		}
+		const cleaned = pathname
+			.replace(/^\//, "")
+			.replace(/\/$/, "")
+			.replace(/\.git$/, "");
+		const segments = cleaned.split("/").filter(Boolean);
+		if (segments.length !== 2) {
+			throw new Error(`GitHub repo URL must have exactly owner/repo path segments: ${input}`);
+		}
+		return { owner: segments[0], repo: segments[1] };
+	}
+
+	// Otherwise treat as owner/repo shorthand
+	const cleaned = input.replace(/\.git$/, "").replace(/\/$/, "");
+	const segments = cleaned.split("/").filter(Boolean);
+	if (segments.length !== 2) {
+		throw new Error(`Expected owner/repo format: ${input}`);
+	}
+	return { owner: segments[0], repo: segments[1] };
+}

--- a/packages/fixbot/src/repo-cache.ts
+++ b/packages/fixbot/src/repo-cache.ts
@@ -324,7 +324,7 @@ export function getCacheStats(config: RepoCacheConfig): RepoCacheStats {
 function estimateDiskUsageMb(dir: string): number {
 	let totalBytes = 0;
 
-	function walkShallow(d: string): void {
+	function walkRecursive(d: string): void {
 		if (!existsSync(d)) return;
 		try {
 			for (const entry of readdirSync(d, { withFileTypes: true })) {
@@ -336,7 +336,7 @@ function estimateDiskUsageMb(dir: string): number {
 						// skip
 					}
 				} else if (entry.isDirectory()) {
-					walkShallow(full);
+					walkRecursive(full);
 				}
 			}
 		} catch {
@@ -344,6 +344,6 @@ function estimateDiskUsageMb(dir: string): number {
 		}
 	}
 
-	walkShallow(dir);
+	walkRecursive(dir);
 	return Math.round(totalBytes / (1024 * 1024));
 }

--- a/packages/fixbot/src/repo-cache.ts
+++ b/packages/fixbot/src/repo-cache.ts
@@ -1,0 +1,349 @@
+/**
+ * Repository cache — reuses bare clones across jobs.
+ *
+ * Layout on disk:
+ *   {cacheDir}/{owner}/{repo}.git/          — bare clone
+ *   {cacheDir}/{owner}/{repo}.git/worktrees/ — git-managed worktree metadata
+ *   {cacheDir}/{owner}/{repo}.git/_worktrees/ — actual worktree working dirs
+ *   {cacheDir}/cache-meta.json               — LRU metadata
+ *
+ * Each job gets its own worktree:
+ *   git worktree add _worktrees/job-{id} -b _worktree/job-{id} origin/{baseBranch}
+ */
+
+import { createHash } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import {
+	addWorktree,
+	bareCloneRepo,
+	configureBareFetchRefspec,
+	fetchBranch,
+	pruneWorktrees,
+	removeWorktree,
+} from "./git";
+import { parseOwnerRepo } from "./github-utils";
+import type { RepoCacheConfig, RepoCacheStats } from "./types";
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_REPO_CACHE_CONFIG: RepoCacheConfig = {
+	enabled: true,
+	dir: join(homedir(), ".fixbot", "repos"),
+	maxRepos: 20,
+	maxDiskMb: 5000,
+	staleBranchDays: 7,
+};
+
+// ---------------------------------------------------------------------------
+// Cache metadata (atomic temp-file + rename)
+// ---------------------------------------------------------------------------
+
+interface CacheMetaEntry {
+	/** owner/repo */
+	key: string;
+	lastUsedAt: string;
+}
+
+interface CacheMeta {
+	version: 1;
+	entries: CacheMetaEntry[];
+}
+
+function metaPath(cacheDir: string): string {
+	return join(cacheDir, "cache-meta.json");
+}
+
+function readMeta(cacheDir: string): CacheMeta {
+	const p = metaPath(cacheDir);
+	if (!existsSync(p)) {
+		return { version: 1, entries: [] };
+	}
+	try {
+		const data = JSON.parse(readFileSync(p, "utf-8")) as CacheMeta;
+		if (data.version === 1 && Array.isArray(data.entries)) {
+			return data;
+		}
+	} catch {
+		// Corrupted — start fresh.
+	}
+	return { version: 1, entries: [] };
+}
+
+function writeMeta(cacheDir: string, meta: CacheMeta): void {
+	const p = metaPath(cacheDir);
+	mkdirSync(dirname(p), { recursive: true });
+	const tmpFile = `${p}.tmp.${process.pid}`;
+	writeFileSync(tmpFile, JSON.stringify(meta, null, 2), "utf-8");
+	renameSync(tmpFile, p);
+}
+
+function touchEntry(meta: CacheMeta, key: string): void {
+	const now = new Date().toISOString();
+	const idx = meta.entries.findIndex((e) => e.key === key);
+	if (idx >= 0) {
+		meta.entries[idx].lastUsedAt = now;
+	} else {
+		meta.entries.push({ key, lastUsedAt: now });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bare directory layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a cache key (owner, repo) from a repo URL.
+ * For GitHub URLs: uses the actual owner/repo.
+ * For local paths (tests): hashes the path into a synthetic key.
+ */
+export function deriveRepoCacheKey(repoUrl: string): { owner: string; repo: string; key: string } {
+	try {
+		const { owner, repo } = parseOwnerRepo(repoUrl);
+		return { owner, repo, key: `${owner}/${repo}` };
+	} catch {
+		// Local filesystem path — derive a deterministic key.
+		const hash = createHash("sha256").update(repoUrl).digest("hex").slice(0, 12);
+		const name = basename(repoUrl).replace(/\.git$/, "") || "repo";
+		return { owner: "_local", repo: `${name}-${hash}`, key: `_local/${name}-${hash}` };
+	}
+}
+
+function bareDirForRepo(cacheDir: string, owner: string, repo: string): string {
+	return join(cacheDir, owner, `${repo}.git`);
+}
+
+function worktreeBaseDirForBare(bareDir: string): string {
+	return join(bareDir, "_worktrees");
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+export interface GetOrCreateWorkspaceOptions {
+	repoUrl: string;
+	baseBranch: string;
+	jobId: string;
+	config: RepoCacheConfig;
+	logger?: (message: string) => void;
+}
+
+export interface WorkspaceResult {
+	workspaceDir: string;
+	bareDir: string;
+	worktreeBranch: string;
+	fromCache: boolean;
+}
+
+/**
+ * Obtain a fresh worktree for a job, creating or reusing a bare clone.
+ *
+ * 1. If the bare clone doesn't exist → `git clone --bare`
+ * 2. Fetch the latest state of `baseBranch`
+ * 3. `git worktree add` a new working directory for this job
+ *
+ * On any git error the bare clone is deleted and re-cloned once (auto-repair).
+ */
+export async function getOrCreateWorkspace(opts: GetOrCreateWorkspaceOptions): Promise<WorkspaceResult> {
+	const { repoUrl, baseBranch, jobId, config, logger } = opts;
+	const { owner, repo, key } = deriveRepoCacheKey(repoUrl);
+	const cacheDir = config.dir;
+	const bareDir = bareDirForRepo(cacheDir, owner, repo);
+	const worktreeBaseDir = worktreeBaseDirForBare(bareDir);
+	const worktreeDir = join(worktreeBaseDir, `job-${jobId}`);
+	const localBranch = `_worktree/job-${jobId}`;
+
+	mkdirSync(dirname(bareDir), { recursive: true });
+
+	let fromCache = true;
+
+	// --- Ensure bare clone exists ---
+	if (!existsSync(bareDir)) {
+		logger?.(`[fixbot] repo-cache: bare-cloning ${repoUrl} → ${bareDir}`);
+		await bareCloneRepo(repoUrl, bareDir);
+		await configureBareFetchRefspec(bareDir);
+		fromCache = false;
+	}
+
+	// --- Attempt fetch + worktree add (with one retry after repair) ---
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			logger?.(`[fixbot] repo-cache: fetching ${baseBranch} in ${bareDir}`);
+			await fetchBranch(bareDir, baseBranch);
+			await pruneWorktrees(bareDir);
+			mkdirSync(worktreeBaseDir, { recursive: true });
+			logger?.(`[fixbot] repo-cache: adding worktree job-${jobId} on ${baseBranch}`);
+			await addWorktree(bareDir, worktreeDir, localBranch, baseBranch);
+
+			// Update LRU metadata
+			const meta = readMeta(cacheDir);
+			touchEntry(meta, key);
+			writeMeta(cacheDir, meta);
+
+			// Evict if over limit
+			await evictLRU(config, logger);
+
+			return { workspaceDir: worktreeDir, bareDir, worktreeBranch: localBranch, fromCache };
+		} catch (err) {
+			if (attempt === 0) {
+				logger?.(
+					`[fixbot] repo-cache: git error, repairing ${bareDir}: ${err instanceof Error ? err.message : String(err)}`,
+				);
+				await repair(bareDir, repoUrl, logger);
+				fromCache = false;
+				continue;
+			}
+			throw err;
+		}
+	}
+
+	// Unreachable, but satisfies TypeScript.
+	throw new Error("repo-cache: unexpected fallthrough in getOrCreateWorkspace");
+}
+
+/**
+ * Remove a job's worktree and its local branch from the bare repo.
+ */
+export async function cleanupWorktree(
+	bareDir: string,
+	jobId: string,
+	logger?: (message: string) => void,
+): Promise<void> {
+	const worktreeDir = join(worktreeBaseDirForBare(bareDir), `job-${jobId}`);
+	const localBranch = `_worktree/job-${jobId}`;
+	logger?.(`[fixbot] repo-cache: removing worktree job-${jobId}`);
+	await removeWorktree(bareDir, worktreeDir, localBranch, logger);
+}
+
+// ---------------------------------------------------------------------------
+// LRU eviction
+// ---------------------------------------------------------------------------
+
+/**
+ * Evict the least-recently-used repos when the cache exceeds `maxRepos`.
+ */
+export async function evictLRU(config: RepoCacheConfig, logger?: (message: string) => void): Promise<void> {
+	const meta = readMeta(config.dir);
+	if (meta.entries.length <= config.maxRepos) {
+		return;
+	}
+
+	// Sort ascending by lastUsedAt so oldest entries are first.
+	const sorted = [...meta.entries].sort(
+		(a, b) => new Date(a.lastUsedAt).getTime() - new Date(b.lastUsedAt).getTime(),
+	);
+
+	const toEvict = sorted.slice(0, sorted.length - config.maxRepos);
+	for (const entry of toEvict) {
+		const [owner, repo] = entry.key.split("/");
+		const bareDir = bareDirForRepo(config.dir, owner, repo);
+		if (existsSync(bareDir)) {
+			logger?.(`[fixbot] repo-cache: evicting ${entry.key} (last used ${entry.lastUsedAt})`);
+			rmSync(bareDir, { recursive: true, force: true });
+		}
+		meta.entries = meta.entries.filter((e) => e.key !== entry.key);
+	}
+
+	writeMeta(config.dir, meta);
+}
+
+// ---------------------------------------------------------------------------
+// Repair
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a corrupted bare clone and re-clone from scratch.
+ */
+export async function repair(bareDir: string, repoUrl: string, logger?: (message: string) => void): Promise<void> {
+	logger?.(`[fixbot] repo-cache: deleting corrupted ${bareDir}`);
+	rmSync(bareDir, { recursive: true, force: true });
+	logger?.(`[fixbot] repo-cache: re-cloning ${repoUrl}`);
+	await bareCloneRepo(repoUrl, bareDir);
+	await configureBareFetchRefspec(bareDir);
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute basic cache statistics for status reporting.
+ */
+export function getCacheStats(config: RepoCacheConfig): RepoCacheStats {
+	const cacheDir = config.dir;
+	if (!existsSync(cacheDir)) {
+		return { repos: 0, activeWorktrees: 0, diskUsageMb: 0 };
+	}
+
+	const meta = readMeta(cacheDir);
+	let activeWorktrees = 0;
+
+	for (const entry of meta.entries) {
+		const [owner, repo] = entry.key.split("/");
+		const wtBase = worktreeBaseDirForBare(bareDirForRepo(cacheDir, owner, repo));
+		if (existsSync(wtBase)) {
+			try {
+				activeWorktrees += readdirSync(wtBase).length;
+			} catch {
+				// Ignore read errors.
+			}
+		}
+	}
+
+	// Estimate disk usage by walking the cache directory.
+	let diskUsageMb = 0;
+	try {
+		diskUsageMb = estimateDiskUsageMb(cacheDir);
+	} catch {
+		// Ignore stat errors.
+	}
+
+	return {
+		repos: meta.entries.length,
+		activeWorktrees,
+		diskUsageMb,
+	};
+}
+
+/**
+ * Rough disk usage estimate in MB.
+ */
+function estimateDiskUsageMb(dir: string): number {
+	let totalBytes = 0;
+
+	function walkShallow(d: string): void {
+		if (!existsSync(d)) return;
+		try {
+			for (const entry of readdirSync(d, { withFileTypes: true })) {
+				const full = join(d, entry.name);
+				if (entry.isFile()) {
+					try {
+						totalBytes += statSync(full).size;
+					} catch {
+						// skip
+					}
+				} else if (entry.isDirectory()) {
+					walkShallow(full);
+				}
+			}
+		} catch {
+			// skip
+		}
+	}
+
+	walkShallow(dir);
+	return Math.round(totalBytes / (1024 * 1024));
+}

--- a/packages/fixbot/src/runner.ts
+++ b/packages/fixbot/src/runner.ts
@@ -23,6 +23,7 @@ import { resolveExecutionModel, resolveHostAgentConfig } from "./host-agent";
 import { assertDockerImageReady } from "./image";
 import { createStderrLogger, type Logger } from "./logger";
 import { deriveResultStatus, parseResultMarkers } from "./markers";
+import { getOrCreateWorkspace, type WorkspaceResult } from "./repo-cache";
 import {
 	EXECUTION_PLAN_VERSION_V1,
 	type ExecutionOutputV1,
@@ -32,6 +33,7 @@ import {
 	type ModelSelection,
 	type DaemonModelConfig,
 	type NormalizedJobSpecV1,
+	type RepoCacheConfig,
 } from "./types";
 
 export interface RunJobOptions {
@@ -43,6 +45,8 @@ export interface RunJobOptions {
 	configModel?: DaemonModelConfig;
 	/** Structured logger. Defaults to a stderr logger scoped to "runner". */
 	logger?: Logger;
+	/** When set, use the repo cache (bare clone + worktrees) instead of a fresh shallow clone. */
+	repoCacheConfig?: RepoCacheConfig;
 }
 
 function writeJson(filePath: string, value: unknown): void {
@@ -149,6 +153,7 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 	let gitStatusText = "";
 	let patchText = "";
 	let selectedModel: ModelSelection | undefined;
+	let cacheResult: WorkspaceResult | undefined;
 
 	try {
 		const hostConfig = resolveHostAgentConfig();
@@ -162,11 +167,40 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 			assertDockerGithubAuth();
 			await dockerImageVerifier();
 		}
-		log.info(`cloning ${job.repo.url} @ ${job.repo.baseBranch}`);
-		await cloneRepository(job.repo.url, job.repo.baseBranch, paths.workspaceDir);
+
+		// Obtain workspace: repo-cache (bare clone + worktree) or fresh shallow clone.
+		const cacheConfig = options.repoCacheConfig;
+		if (cacheConfig?.enabled) {
+			try {
+				log.info(`repo-cache: preparing workspace for ${job.repo.url} @ ${job.repo.baseBranch}`);
+				cacheResult = await getOrCreateWorkspace({
+					repoUrl: job.repo.url,
+					baseBranch: job.repo.baseBranch,
+					jobId: job.jobId,
+					config: cacheConfig,
+					logger: (msg) => log.info(msg),
+				});
+				// Override the workspace dir to the worktree location.
+				(paths as { workspaceDir: string }).workspaceDir = cacheResult.workspaceDir;
+				log.info(
+					`repo-cache: workspace ready at ${cacheResult.workspaceDir} (fromCache=${cacheResult.fromCache})`,
+				);
+			} catch (cacheError) {
+				log.warn(
+					`repo-cache: failed, falling back to fresh clone: ${cacheError instanceof Error ? cacheError.message : String(cacheError)}`,
+				);
+				cacheResult = undefined;
+			}
+		}
+
+		if (!cacheResult) {
+			log.info(`cloning ${job.repo.url} @ ${job.repo.baseBranch}`);
+			await cloneRepository(job.repo.url, job.repo.baseBranch, paths.workspaceDir);
+		}
+
 		await configureLocalGitIdentity(paths.workspaceDir);
 		baseCommit = await getHeadCommit(paths.workspaceDir);
-		log.info(`repository cloned at ${baseCommit}`);
+		log.info(`repository ready at ${baseCommit}`);
 		writeJson(paths.executionPlanFile, buildExecutionPlan(job, baseCommit, selectedModel));
 
 		const context: PreparedJobContext = {

--- a/packages/fixbot/src/runner.ts
+++ b/packages/fixbot/src/runner.ts
@@ -139,6 +139,8 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 	const executor = options.executor ?? createDefaultPreparedJobExecutor();
 	const dockerImageVerifier = options.dockerImageVerifier ?? (() => assertDockerImageReady());
 	const paths = getArtifactPaths(resultsDir, job.jobId);
+	/** Mutable workspace directory — may be overridden by repo-cache worktree. */
+	let workspaceDir = paths.workspaceDir;
 
 	log.info(`starting job ${job.jobId} (${job.execution.mode})`);
 	log.info(`results will be written under ${paths.artifactDir}`);
@@ -180,10 +182,10 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 					config: cacheConfig,
 					logger: (msg) => log.info(msg),
 				});
-				// Override the workspace dir to the worktree location.
-				(paths as { workspaceDir: string }).workspaceDir = cacheResult.workspaceDir;
+				// Use the worktree location instead of the default workspace dir.
+				workspaceDir = cacheResult.workspaceDir;
 				log.info(
-					`repo-cache: workspace ready at ${cacheResult.workspaceDir} (fromCache=${cacheResult.fromCache})`,
+					`repo-cache: workspace ready at ${workspaceDir} (fromCache=${cacheResult.fromCache})`,
 				);
 			} catch (cacheError) {
 				log.warn(
@@ -195,17 +197,17 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 
 		if (!cacheResult) {
 			log.info(`cloning ${job.repo.url} @ ${job.repo.baseBranch}`);
-			await cloneRepository(job.repo.url, job.repo.baseBranch, paths.workspaceDir);
+			await cloneRepository(job.repo.url, job.repo.baseBranch, workspaceDir);
 		}
 
-		await configureLocalGitIdentity(paths.workspaceDir);
-		baseCommit = await getHeadCommit(paths.workspaceDir);
+		await configureLocalGitIdentity(workspaceDir);
+		baseCommit = await getHeadCommit(workspaceDir);
 		log.info(`repository ready at ${baseCommit}`);
 		writeJson(paths.executionPlanFile, buildExecutionPlan(job, baseCommit, selectedModel));
 
 		const context: PreparedJobContext = {
 			job,
-			paths,
+			paths: { ...paths, workspaceDir },
 			baseCommit,
 			hostConfig,
 			selectedModel,
@@ -218,30 +220,30 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 		executionError = error instanceof Error ? error.message : String(error);
 		log.error(`execution failed: ${executionError}`);
 	} finally {
-		if (existsSync(paths.workspaceDir)) {
+		if (existsSync(workspaceDir)) {
 			log.info("capturing workspace artifacts");
 			try {
-				headCommit = await getHeadCommit(paths.workspaceDir);
+				headCommit = await getHeadCommit(workspaceDir);
 			} catch {
 				headCommit = undefined;
 			}
 
 			try {
-				patchText = baseCommit ? await capturePatch(paths.workspaceDir, baseCommit, paths.patchFile) : "";
+				patchText = baseCommit ? await capturePatch(workspaceDir, baseCommit, paths.patchFile) : "";
 			} catch {
 				patchText = safeReadFile(paths.patchFile);
 			}
 
 			try {
-				gitStatusText = await captureGitStatus(paths.workspaceDir, paths.gitStatusFile);
+				gitStatusText = await captureGitStatus(workspaceDir, paths.gitStatusFile);
 			} catch {
 				gitStatusText = safeReadFile(paths.gitStatusFile);
 			}
 
-			copyOptionalWorkspaceArtifact(paths.workspaceDir, "TODO.md", paths.todoFile);
-			copyOptionalWorkspaceArtifact(paths.workspaceDir, "ci-log.txt", paths.ciLogFile);
+			copyOptionalWorkspaceArtifact(workspaceDir, "TODO.md", paths.todoFile);
+			copyOptionalWorkspaceArtifact(workspaceDir, "ci-log.txt", paths.ciLogFile);
 			if (!existsSync(paths.ciLogFile)) {
-				copyOptionalWorkspaceArtifact(paths.workspaceDir, ".fixbot/ci-log.txt", paths.ciLogFile);
+				copyOptionalWorkspaceArtifact(workspaceDir, ".fixbot/ci-log.txt", paths.ciLogFile);
 			}
 		}
 	}
@@ -281,7 +283,7 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 	// The agent typically commits its work, so `git status --short` shows a clean tree
 	// while the actual diff vs baseCommit has real changes.
 	const uncommittedCount = countChangedFilesFromStatus(gitStatusText);
-	const committedCount = baseCommit ? await countCommittedChangedFiles(paths.workspaceDir, baseCommit) : 0;
+	const committedCount = baseCommit ? await countCommittedChangedFiles(workspaceDir, baseCommit) : 0;
 	const changedFileCount = Math.max(uncommittedCount, committedCount);
 	const result: JobResultV1 = {
 		version: JOB_RESULT_VERSION_V1,
@@ -303,7 +305,7 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 			sandbox: job.execution.sandbox,
 			model: job.execution.model,
 			selectedModel: executionOutput?.model ?? selectedModel,
-			workspaceDir: paths.workspaceDir,
+			workspaceDir,
 			baseCommit,
 			headCommit,
 			startedAt: startedAt.toISOString(),

--- a/packages/fixbot/src/types.ts
+++ b/packages/fixbot/src/types.ts
@@ -271,6 +271,7 @@ export interface DaemonConfigV1 {
 	github?: DaemonGitHubConfig;
 	identity?: { botUrl?: string };
 	model?: DaemonModelConfig;
+	repoCache?: Partial<RepoCacheConfig>;
 }
 
 export interface DaemonResolvedPaths {
@@ -300,6 +301,7 @@ export interface NormalizedDaemonConfigV1 {
 	github?: NormalizedDaemonGitHubConfig;
 	identity: { botUrl: string };
 	model?: DaemonModelConfig;
+	repoCache?: RepoCacheConfig;
 }
 
 export interface DaemonErrorSummary {
@@ -392,4 +394,22 @@ export interface DaemonStatusSnapshotV1 {
 	queue: DaemonQueueStatusV1;
 	activeJob: DaemonActiveJobStatusV1 | null;
 	recentResults: DaemonRecentResultSummaryV1[];
+}
+
+// ---------------------------------------------------------------------------
+// Repository cache types
+// ---------------------------------------------------------------------------
+
+export interface RepoCacheConfig {
+	enabled: boolean;
+	dir: string;
+	maxRepos: number;
+	maxDiskMb: number;
+	staleBranchDays: number;
+}
+
+export interface RepoCacheStats {
+	repos: number;
+	activeWorktrees: number;
+	diskUsageMb: number;
 }

--- a/packages/fixbot/test/repo-cache.test.ts
+++ b/packages/fixbot/test/repo-cache.test.ts
@@ -1,0 +1,482 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { parseOwnerRepo } from "../src/github-utils";
+import {
+	cleanupWorktree,
+	DEFAULT_REPO_CACHE_CONFIG,
+	evictLRU,
+	getCacheStats,
+	getOrCreateWorkspace,
+	repair,
+	type WorkspaceResult,
+} from "../src/repo-cache";
+import type { RepoCacheConfig } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpRoot(): string {
+	const dir = join(tmpdir(), `fixbot-repo-cache-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+/** Create a local git repo that can be used as a remote origin. */
+function createOriginRepo(rootDir: string, name = "origin-repo"): string {
+	const repoDir = join(rootDir, name);
+	mkdirSync(repoDir, { recursive: true });
+	execFileSync("git", ["init", "-b", "main"], { cwd: repoDir });
+	execFileSync("git", ["config", "user.name", "Test"], { cwd: repoDir });
+	execFileSync("git", ["config", "user.email", "test@test.local"], { cwd: repoDir });
+	writeFileSync(join(repoDir, "README.md"), "# hello\n");
+	execFileSync("git", ["add", "."], { cwd: repoDir });
+	execFileSync("git", ["commit", "-m", "initial"], { cwd: repoDir });
+	return repoDir;
+}
+
+function makeConfig(rootDir: string, overrides?: Partial<RepoCacheConfig>): RepoCacheConfig {
+	return {
+		...DEFAULT_REPO_CACHE_CONFIG,
+		dir: join(rootDir, "cache"),
+		maxRepos: 5,
+		maxDiskMb: 5000,
+		staleBranchDays: 7,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// parseOwnerRepo (from github-utils)
+// ---------------------------------------------------------------------------
+
+describe("parseOwnerRepo", () => {
+	it("parses HTTPS URL", () => {
+		expect(parseOwnerRepo("https://github.com/acme/widgets")).toEqual({
+			owner: "acme",
+			repo: "widgets",
+		});
+	});
+
+	it("parses HTTPS URL with .git suffix", () => {
+		expect(parseOwnerRepo("https://github.com/acme/widgets.git")).toEqual({
+			owner: "acme",
+			repo: "widgets",
+		});
+	});
+
+	it("parses owner/repo shorthand", () => {
+		expect(parseOwnerRepo("acme/widgets")).toEqual({ owner: "acme", repo: "widgets" });
+	});
+
+	it("throws on invalid URL", () => {
+		expect(() => parseOwnerRepo("https://github.com/only-one")).toThrow();
+	});
+
+	it("throws on single segment shorthand", () => {
+		expect(() => parseOwnerRepo("only-one")).toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getOrCreateWorkspace
+// ---------------------------------------------------------------------------
+
+describe("getOrCreateWorkspace", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("creates a bare clone and worktree for a new repo", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "test-001",
+			config,
+			logger: () => {},
+		});
+
+		expect(result.fromCache).toBe(false);
+		expect(existsSync(result.workspaceDir)).toBe(true);
+		expect(existsSync(join(result.workspaceDir, "README.md"))).toBe(true);
+		expect(result.worktreeBranch).toBe("_worktree/job-test-001");
+	});
+
+	it("reuses bare clone on second call (fromCache=true)", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const first = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "job-a",
+			config,
+			logger: () => {},
+		});
+		expect(first.fromCache).toBe(false);
+
+		const second = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "job-b",
+			config,
+			logger: () => {},
+		});
+		expect(second.fromCache).toBe(true);
+		expect(second.bareDir).toBe(first.bareDir);
+		expect(second.workspaceDir).not.toBe(first.workspaceDir);
+	});
+
+	it("worktree has correct content from base branch", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "content-check",
+			config,
+			logger: () => {},
+		});
+
+		const readme = readFileSync(join(result.workspaceDir, "README.md"), "utf-8");
+		expect(readme).toBe("# hello\n");
+	});
+
+	it("fetches latest changes when reusing bare clone", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		// First call to seed cache
+		await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "seed",
+			config,
+			logger: () => {},
+		});
+
+		// Push new content to origin
+		writeFileSync(join(origin, "NEW.md"), "new file\n");
+		execFileSync("git", ["add", "."], { cwd: origin });
+		execFileSync("git", ["commit", "-m", "add NEW.md"], { cwd: origin });
+
+		// Second call should see new content
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "updated",
+			config,
+			logger: () => {},
+		});
+		expect(existsSync(join(result.workspaceDir, "NEW.md"))).toBe(true);
+	});
+
+	it("auto-repairs corrupted bare clone", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		// Seed cache
+		const first = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "before-corrupt",
+			config,
+			logger: () => {},
+		});
+
+		// Corrupt the bare repo by deleting HEAD
+		const headFile = join(first.bareDir, "HEAD");
+		if (existsSync(headFile)) {
+			rmSync(headFile);
+		}
+
+		// Next call should repair and still succeed
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "after-corrupt",
+			config,
+			logger: () => {},
+		});
+		expect(existsSync(result.workspaceDir)).toBe(true);
+		expect(result.fromCache).toBe(false); // was re-cloned
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cleanupWorktree
+// ---------------------------------------------------------------------------
+
+describe("cleanupWorktree", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("removes a worktree created by getOrCreateWorkspace", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "to-cleanup",
+			config,
+			logger: () => {},
+		});
+		expect(existsSync(result.workspaceDir)).toBe(true);
+
+		await cleanupWorktree(result.bareDir, "to-cleanup", () => {});
+		expect(existsSync(result.workspaceDir)).toBe(false);
+	});
+
+	it("is safe to call twice (idempotent)", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "double-cleanup",
+			config,
+			logger: () => {},
+		});
+
+		await cleanupWorktree(result.bareDir, "double-cleanup", () => {});
+		// Second call should not throw
+		await cleanupWorktree(result.bareDir, "double-cleanup", () => {});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// evictLRU
+// ---------------------------------------------------------------------------
+
+describe("evictLRU", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("evicts oldest repos when cache exceeds maxRepos", async () => {
+		const config = makeConfig(rootDir, { maxRepos: 2 });
+
+		// Create 3 origin repos
+		const repos: string[] = [];
+		for (let i = 0; i < 3; i++) {
+			repos.push(createOriginRepo(rootDir, `repo-${i}`));
+		}
+
+		// Populate cache with 3 repos
+		for (let i = 0; i < 3; i++) {
+			await getOrCreateWorkspace({
+				repoUrl: repos[i],
+				baseBranch: "main",
+				jobId: `evict-${i}`,
+				config,
+				logger: () => {},
+			});
+		}
+
+		// After the 3rd, eviction should have removed the first repo
+		// (since maxRepos=2, the oldest should be evicted)
+		const stats = getCacheStats(config);
+		expect(stats.repos).toBeLessThanOrEqual(2);
+	});
+
+	it("does nothing when under the limit", async () => {
+		const config = makeConfig(rootDir, { maxRepos: 10 });
+		const origin = createOriginRepo(rootDir);
+
+		await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "no-evict",
+			config,
+			logger: () => {},
+		});
+
+		const stats = getCacheStats(config);
+		expect(stats.repos).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// repair
+// ---------------------------------------------------------------------------
+
+describe("repair", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("re-clones a bare repo after deletion", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "pre-repair",
+			config,
+			logger: () => {},
+		});
+
+		await repair(result.bareDir, origin, () => {});
+		expect(existsSync(result.bareDir)).toBe(true);
+
+		// Verify it's a working bare repo by creating a new worktree
+		const result2 = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "post-repair",
+			config,
+			logger: () => {},
+		});
+		expect(existsSync(result2.workspaceDir)).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getCacheStats
+// ---------------------------------------------------------------------------
+
+describe("getCacheStats", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("returns zeros for empty cache", () => {
+		const config = makeConfig(rootDir);
+		const stats = getCacheStats(config);
+		expect(stats.repos).toBe(0);
+		expect(stats.activeWorktrees).toBe(0);
+	});
+
+	it("counts repos and worktrees", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "stat-1",
+			config,
+			logger: () => {},
+		});
+		await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "stat-2",
+			config,
+			logger: () => {},
+		});
+
+		const stats = getCacheStats(config);
+		expect(stats.repos).toBe(1);
+		expect(stats.activeWorktrees).toBe(2);
+	});
+
+	it("decrements worktree count after cleanup", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		const result = await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "stat-cleanup",
+			config,
+			logger: () => {},
+		});
+
+		await cleanupWorktree(result.bareDir, "stat-cleanup", () => {});
+
+		const stats = getCacheStats(config);
+		expect(stats.repos).toBe(1);
+		expect(stats.activeWorktrees).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Config defaults
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_REPO_CACHE_CONFIG", () => {
+	it("has sensible defaults", () => {
+		expect(DEFAULT_REPO_CACHE_CONFIG.enabled).toBe(true);
+		expect(DEFAULT_REPO_CACHE_CONFIG.maxRepos).toBeGreaterThan(0);
+		expect(DEFAULT_REPO_CACHE_CONFIG.maxDiskMb).toBeGreaterThan(0);
+		expect(DEFAULT_REPO_CACHE_CONFIG.staleBranchDays).toBeGreaterThan(0);
+		expect(DEFAULT_REPO_CACHE_CONFIG.dir).toContain(".fixbot");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cache metadata persistence
+// ---------------------------------------------------------------------------
+
+describe("cache metadata", () => {
+	let rootDir: string;
+
+	beforeEach(() => {
+		rootDir = tmpRoot();
+	});
+
+	afterEach(() => {
+		rmSync(rootDir, { recursive: true, force: true });
+	});
+
+	it("persists metadata across calls", async () => {
+		const origin = createOriginRepo(rootDir);
+		const config = makeConfig(rootDir);
+
+		await getOrCreateWorkspace({
+			repoUrl: origin,
+			baseBranch: "main",
+			jobId: "meta-1",
+			config,
+			logger: () => {},
+		});
+
+		const metaFile = join(config.dir, "cache-meta.json");
+		expect(existsSync(metaFile)).toBe(true);
+		const meta = JSON.parse(readFileSync(metaFile, "utf-8"));
+		expect(meta.version).toBe(1);
+		expect(meta.entries.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a repository cache that reuses **bare clones** across jobs, creating lightweight **git worktrees** per job instead of fresh shallow clones
- Bare clones are stored in `~/.fixbot/repos/` with LRU eviction (configurable `maxRepos`)
- Auto-repair: corrupted bare clones are deleted and re-cloned transparently
- Runner gracefully falls back to a fresh shallow clone when the cache is disabled or encounters an error
- Daemon service passes `repoCacheConfig` from daemon config and cleans up worktrees in the `finally` block after each job

### New files
- `packages/fixbot/src/repo-cache.ts` — core cache module (~350 LOC)
- `packages/fixbot/src/github-utils.ts` — shared `parseOwnerRepo` utility
- `packages/fixbot/test/repo-cache.test.ts` — 20 tests covering all cache operations

### Modified files
- `packages/fixbot/src/git.ts` — bare clone/worktree git primitives
- `packages/fixbot/src/types.ts` — `RepoCacheConfig`, `RepoCacheStats` interfaces
- `packages/fixbot/src/config.ts` — `normalizeRepoCacheConfig` + daemon config integration
- `packages/fixbot/src/runner.ts` — repo-cache workspace with fallback to fresh clone
- `packages/fixbot/src/daemon/service.ts` — pass config to runner, worktree cleanup

Closes #15

## Test plan

- [x] `bun test test/repo-cache.test.ts` — 20 tests pass (bare clone, worktree reuse, eviction, repair, stats, metadata persistence)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: configure `repoCache` in daemon config, run a job, verify worktree is created and cleaned up
- [ ] Manual: run two jobs for same repo, verify second reuses bare clone (`fromCache=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)