### PR TITLE
feat: per-repo job learnings with pattern detection

### DIFF
--- a/packages/fixbot/src/learnings.ts
+++ b/packages/fixbot/src/learnings.ts
@@ -72,7 +72,7 @@ export function classifyError(result: JobResultV1): ErrorCategory | null {
 	if (text.includes("rate limit") || text.includes("rate_limit") || text.includes("429") || text.includes("too many requests")) {
 		return "rate_limit";
 	}
-	if (text.includes("refus") || text.includes("content policy") || text.includes("safety")) {
+	if (text.includes("refused") || text.includes("refusal") || text.includes("content policy") || text.includes("safety")) {
 		return "model_refusal";
 	}
 	if (text.includes("no changes") || text.includes("no fix") || text.includes("nothing to commit")) {

--- a/packages/fixbot/src/learnings.ts
+++ b/packages/fixbot/src/learnings.ts
@@ -1,0 +1,296 @@
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_FIXBOT_DIR } from "./config";
+import {
+	type ErrorCategory,
+	type JobResultV1,
+	LEARNING_ENTRY_VERSION_V1,
+	type LearningEntryV1,
+	type ResultStatus,
+} from "./types";
+
+const LEARNINGS_FILE = "learnings.jsonl";
+const MAX_ENTRIES = 100;
+const INJECT_COUNT = 10;
+const MAX_SUMMARY_LENGTH = 200;
+
+// ---------------------------------------------------------------------------
+// Repo URL → filesystem-safe slug
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a repo URL to a filesystem-safe slug.
+ *
+ * Handles HTTPS URLs (https://github.com/owner/repo.git),
+ * SSH URLs (git@github.com:owner/repo.git), and falls back
+ * to a SHA-256 hash prefix for anything unexpected.
+ */
+export function repoUrlToSlug(url: string): string {
+	// Try HTTPS: https://github.com/owner/repo.git or https://github.com/owner/repo
+	const httpsMatch = url.match(/^https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+	if (httpsMatch) {
+		return `${httpsMatch[1]}__${httpsMatch[2]}`;
+	}
+
+	// Try SSH: git@github.com:owner/repo.git or git@github.com:owner/repo
+	const sshMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+	if (sshMatch) {
+		return `${sshMatch[1]}__${sshMatch[2]}`;
+	}
+
+	// Fallback: SHA-256 hash prefix
+	const hash = createHash("sha256").update(url).digest("hex").slice(0, 16);
+	return `_hash_${hash}`;
+}
+
+/**
+ * Get (and ensure existence of) the per-repo learnings directory.
+ * Returns the path: ~/.fixbot/repos/{owner}__{repo}/
+ */
+function getLearningsDir(repoUrl: string): string {
+	const slug = repoUrlToSlug(repoUrl);
+	const dir = join(DEFAULT_FIXBOT_DIR, "repos", slug);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Error category detection
+// ---------------------------------------------------------------------------
+
+/** Derive an ErrorCategory from a job result, or null for clean successes. */
+export function classifyError(result: JobResultV1): ErrorCategory | null {
+	if (result.status === "success") return null;
+	if (result.status === "timeout") return "timeout";
+
+	const text = `${result.summary ?? ""} ${result.failureReason ?? ""}`.toLowerCase();
+
+	if (text.includes("auth") || text.includes("permission") || text.includes("credentials") || text.includes("401") || text.includes("403")) {
+		return "auth_error";
+	}
+	if (text.includes("rate limit") || text.includes("rate_limit") || text.includes("429") || text.includes("too many requests")) {
+		return "rate_limit";
+	}
+	if (text.includes("refus") || text.includes("content policy") || text.includes("safety")) {
+		return "model_refusal";
+	}
+	if (text.includes("no changes") || text.includes("no fix") || text.includes("nothing to commit")) {
+		return "no_changes";
+	}
+	if (text.includes("build fail") || text.includes("compile") || text.includes("compilation")) {
+		return "build_failure";
+	}
+	if (text.includes("test fail") || text.includes("tests fail") || text.includes("test suite")) {
+		return "test_failure";
+	}
+	return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// JSONL read / write
+// ---------------------------------------------------------------------------
+
+function getLearningsPath(repoUrl: string): string {
+	return join(getLearningsDir(repoUrl), LEARNINGS_FILE);
+}
+
+function truncateSummary(summary: string): string {
+	if (summary.length <= MAX_SUMMARY_LENGTH) return summary;
+	return `${summary.slice(0, MAX_SUMMARY_LENGTH - 3)}...`;
+}
+
+/** Build a LearningEntryV1 from a completed job result. */
+export function buildLearningEntry(result: JobResultV1): LearningEntryV1 {
+	return {
+		version: LEARNING_ENTRY_VERSION_V1,
+		jobId: result.jobId,
+		taskClass: result.taskClass,
+		status: result.status,
+		errorCategory: classifyError(result),
+		summary: truncateSummary(result.summary),
+		durationMs: result.execution.durationMs,
+		timestamp: result.execution.finishedAt,
+	};
+}
+
+/** Append a learning entry to the per-repo JSONL file. */
+export function appendLearning(repoUrl: string, entry: LearningEntryV1): void {
+	const filePath = getLearningsPath(repoUrl);
+	appendFileSync(filePath, `${JSON.stringify(entry)}\n`, "utf-8");
+}
+
+/** Read all learning entries from the per-repo JSONL file. */
+export function readLearnings(repoUrl: string): LearningEntryV1[] {
+	const filePath = getLearningsPath(repoUrl);
+	if (!existsSync(filePath)) return [];
+
+	const content = readFileSync(filePath, "utf-8").trim();
+	if (content === "") return [];
+
+	const entries: LearningEntryV1[] = [];
+	for (const line of content.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed === "") continue;
+		try {
+			const parsed = JSON.parse(trimmed) as LearningEntryV1;
+			if (parsed.version === LEARNING_ENTRY_VERSION_V1) {
+				entries.push(parsed);
+			}
+		} catch {
+			// Skip malformed lines silently
+		}
+	}
+	return entries;
+}
+
+/**
+ * Rotate the learnings file if it exceeds MAX_ENTRIES.
+ * Keeps the most recent MAX_ENTRIES entries using atomic rename.
+ */
+export function rotateLearnings(repoUrl: string): void {
+	const filePath = getLearningsPath(repoUrl);
+	if (!existsSync(filePath)) return;
+
+	const entries = readLearnings(repoUrl);
+	if (entries.length <= MAX_ENTRIES) return;
+
+	const kept = entries.slice(-MAX_ENTRIES);
+	const tmpPath = `${filePath}.tmp`;
+	writeFileSync(tmpPath, `${kept.map((e) => JSON.stringify(e)).join("\n")}\n`, "utf-8");
+	renameSync(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Pattern detection
+// ---------------------------------------------------------------------------
+
+interface PatternInsight {
+	message: string;
+}
+
+/**
+ * Detect simple patterns from recent learning entries.
+ * Analyses the last 10 entries for recurring error categories.
+ */
+export function detectPatterns(entries: LearningEntryV1[]): PatternInsight[] {
+	const recent = entries.slice(-INJECT_COUNT);
+	if (recent.length < 2) return [];
+
+	const insights: PatternInsight[] = [];
+
+	// Count error categories
+	const categoryCounts = new Map<ErrorCategory, number>();
+	let failCount = 0;
+	for (const entry of recent) {
+		if (entry.errorCategory) {
+			categoryCounts.set(entry.errorCategory, (categoryCounts.get(entry.errorCategory) ?? 0) + 1);
+			failCount++;
+		}
+	}
+
+	// Flag if majority of recent jobs are failing
+	if (failCount > recent.length / 2) {
+		insights.push({ message: `${failCount}/${recent.length} recent jobs failed.` });
+	}
+
+	// Flag dominant error category (>= 3 occurrences)
+	for (const [category, count] of categoryCounts) {
+		if (count >= 3) {
+			insights.push({ message: `Recurring ${category}: seen ${count} times in last ${recent.length} jobs.` });
+		}
+	}
+
+	// Flag if recent jobs are getting slower (compare first half vs second half averages)
+	if (recent.length >= 4) {
+		const mid = Math.floor(recent.length / 2);
+		const firstHalf = recent.slice(0, mid);
+		const secondHalf = recent.slice(mid);
+		const avgFirst = firstHalf.reduce((sum, e) => sum + e.durationMs, 0) / firstHalf.length;
+		const avgSecond = secondHalf.reduce((sum, e) => sum + e.durationMs, 0) / secondHalf.length;
+		if (avgSecond > avgFirst * 1.5 && avgSecond - avgFirst > 30_000) {
+			insights.push({ message: "Recent jobs are trending slower." });
+		}
+	}
+
+	return insights;
+}
+
+// ---------------------------------------------------------------------------
+// Context formatting (for injection into agent prompts)
+// ---------------------------------------------------------------------------
+
+function formatStatus(status: ResultStatus): string {
+	switch (status) {
+		case "success":
+			return "OK";
+		case "failed":
+			return "FAIL";
+		case "timeout":
+			return "TIMEOUT";
+	}
+}
+
+function formatDurationShort(ms: number): string {
+	const totalSeconds = Math.round(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	if (minutes > 0) return `${minutes}m${seconds}s`;
+	return `${seconds}s`;
+}
+
+/**
+ * Format recent learnings into a markdown section suitable for injection
+ * into the agent's context. Returns undefined if there are no learnings.
+ */
+export function formatLearningsContext(repoUrl: string): string | undefined {
+	const entries = readLearnings(repoUrl);
+	if (entries.length === 0) return undefined;
+
+	const recent = entries.slice(-INJECT_COUNT);
+	const patterns = detectPatterns(entries);
+
+	const lines: string[] = [
+		"## Recent Job History",
+		"",
+	];
+
+	for (const entry of recent) {
+		const status = formatStatus(entry.status);
+		const duration = formatDurationShort(entry.durationMs);
+		const category = entry.errorCategory ? ` [${entry.errorCategory}]` : "";
+		lines.push(`- ${status} ${entry.taskClass} (${duration})${category}: ${entry.summary}`);
+	}
+
+	if (patterns.length > 0) {
+		lines.push("");
+		lines.push("**Patterns:**");
+		for (const p of patterns) {
+			lines.push(`- ${p.message}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// High-level: record a learning from a completed job (safe, never throws)
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a learning entry after job completion.
+ * All operations are wrapped in try/catch — failures are logged at warn level, never crash jobs.
+ */
+export function recordLearning(
+	result: JobResultV1,
+	logger?: { warn: (msg: string) => void },
+): void {
+	try {
+		const entry = buildLearningEntry(result);
+		appendLearning(result.repo.url, entry);
+		rotateLearnings(result.repo.url);
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		logger?.warn(`failed to record learning: ${msg}`);
+	}
+}

--- a/packages/fixbot/src/runner.ts
+++ b/packages/fixbot/src/runner.ts
@@ -22,6 +22,7 @@ import {
 import { resolveExecutionModel, resolveHostAgentConfig } from "./host-agent";
 import { assertDockerImageReady } from "./image";
 import { createStderrLogger, type Logger } from "./logger";
+import { recordLearning } from "./learnings";
 import { deriveResultStatus, parseResultMarkers } from "./markers";
 import {
 	EXECUTION_PLAN_VERSION_V1,
@@ -79,7 +80,7 @@ function buildExecutionPlan(
 }
 
 /** Format milliseconds as a human-readable duration, e.g. "2m 18s" or "45s". */
-function formatDuration(ms: number): string {
+export function formatDuration(ms: number): string {
 	const totalSeconds = Math.round(ms / 1000);
 	const hours = Math.floor(totalSeconds / 3600);
 	const minutes = Math.floor((totalSeconds % 3600) / 60);
@@ -300,6 +301,7 @@ export async function runJob(job: NormalizedJobSpecV1, options: RunJobOptions = 
 
 	writeJson(paths.resultFile, result);
 	logFinalSummary(log, result, job);
+	recordLearning(result, log);
 	log.info(`result JSON written to ${paths.resultFile}`);
 	return result;
 }

--- a/packages/fixbot/src/types.ts
+++ b/packages/fixbot/src/types.ts
@@ -5,6 +5,19 @@ export const EXECUTION_OUTPUT_VERSION_V1 = "fixbot.execution-output/v1" as const
 export const DAEMON_CONFIG_VERSION_V1 = "fixbot.daemon-config/v1" as const;
 export const DAEMON_STATUS_VERSION_V1 = "fixbot.daemon-status/v1" as const;
 export const DAEMON_JOB_ENVELOPE_VERSION_V1 = "fixbot.daemon-job-envelope/v1" as const;
+export const LEARNING_ENTRY_VERSION_V1 = "fixbot.learning/v1" as const;
+
+export const ERROR_CATEGORIES = [
+	"timeout",
+	"auth_error",
+	"no_changes",
+	"rate_limit",
+	"model_refusal",
+	"build_failure",
+	"test_failure",
+	"unknown",
+] as const;
+export type ErrorCategory = (typeof ERROR_CATEGORIES)[number];
 
 export const DAEMON_LIFECYCLE_STATES = ["starting", "idle", "running", "degraded", "error"] as const;
 
@@ -392,4 +405,19 @@ export interface DaemonStatusSnapshotV1 {
 	queue: DaemonQueueStatusV1;
 	activeJob: DaemonActiveJobStatusV1 | null;
 	recentResults: DaemonRecentResultSummaryV1[];
+}
+
+// ---------------------------------------------------------------------------
+// Per-repo learning types
+// ---------------------------------------------------------------------------
+
+export interface LearningEntryV1 {
+	version: typeof LEARNING_ENTRY_VERSION_V1;
+	jobId: string;
+	taskClass: TaskClass;
+	status: ResultStatus;
+	errorCategory: ErrorCategory | null;
+	summary: string;
+	durationMs: number;
+	timestamp: string;
 }

--- a/packages/fixbot/test/learnings.test.ts
+++ b/packages/fixbot/test/learnings.test.ts
@@ -386,12 +386,14 @@ describe("recordLearning", () => {
 		expect(entries[0].jobId).toBe("job-1");
 	});
 
-	it("does not throw on error, logs warning", () => {
+	it("does not throw when recording succeeds with a logger attached", () => {
 		const warnings: string[] = [];
 		const logger = { warn: (msg: string) => warnings.push(msg) };
 
 		const result = makeResult({ repo: { url: testRepoUrl, baseBranch: "main" } });
 		// Should not throw
 		expect(() => recordLearning(result, logger)).not.toThrow();
+		// No warnings expected on success
+		expect(warnings).toHaveLength(0);
 	});
 });

--- a/packages/fixbot/test/learnings.test.ts
+++ b/packages/fixbot/test/learnings.test.ts
@@ -1,0 +1,397 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	appendLearning,
+	buildLearningEntry,
+	classifyError,
+	detectPatterns,
+	formatLearningsContext,
+	readLearnings,
+	recordLearning,
+	repoUrlToSlug,
+	rotateLearnings,
+} from "../src/learnings";
+import type { JobResultV1, LearningEntryV1 } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Compute the on-disk dir for a given repo URL (mirrors learnings.ts logic). */
+function repoCacheDir(repoUrl: string): string {
+	return join(homedir(), ".fixbot", "repos", repoUrlToSlug(repoUrl));
+}
+
+function cleanupRepoDir(repoUrl: string): void {
+	try {
+		rmSync(repoCacheDir(repoUrl), { recursive: true, force: true });
+	} catch {
+		// ignore
+	}
+}
+
+function makeResult(overrides: Partial<JobResultV1> = {}): JobResultV1 {
+	return {
+		version: "fixbot.result/v1",
+		jobId: overrides.jobId ?? "job-1",
+		taskClass: overrides.taskClass ?? "fix_ci",
+		status: overrides.status ?? "success",
+		summary: overrides.summary ?? "Fixed the CI build.",
+		failureReason: overrides.failureReason,
+		repo: overrides.repo ?? { url: "https://github.com/test/repo.git", baseBranch: "main" },
+		execution: {
+			mode: "process",
+			timeoutMs: 600000,
+			memoryLimitMb: 4096,
+			sandbox: { mode: "workspace-write", networkAccess: true },
+			workspaceDir: "/tmp/ws",
+			startedAt: "2025-01-01T00:00:00.000Z",
+			finishedAt: "2025-01-01T00:02:00.000Z",
+			durationMs: overrides.execution?.durationMs ?? 120000,
+			...overrides.execution,
+		},
+		artifacts: {
+			resultFile: "/tmp/result.json",
+			rootDir: "/tmp/artifacts",
+			jobSpecFile: "/tmp/job.json",
+			patchFile: "/tmp/patch.diff",
+			traceFile: "/tmp/trace.jsonl",
+			assistantFinalFile: "/tmp/final.txt",
+		},
+		diagnostics: {
+			patchSha256: "abc123",
+			changedFileCount: 2,
+			markers: { result: true, summary: true, failureReason: false },
+		},
+	};
+}
+
+function makeEntry(overrides: Partial<LearningEntryV1> = {}): LearningEntryV1 {
+	return {
+		version: "fixbot.learning/v1",
+		jobId: overrides.jobId ?? "job-1",
+		taskClass: overrides.taskClass ?? "fix_ci",
+		status: overrides.status ?? "success",
+		errorCategory: overrides.errorCategory ?? null,
+		summary: overrides.summary ?? "Fixed the CI build.",
+		durationMs: overrides.durationMs ?? 120000,
+		timestamp: overrides.timestamp ?? "2025-01-01T00:02:00.000Z",
+	};
+}
+
+// ---------------------------------------------------------------------------
+// repoUrlToSlug
+// ---------------------------------------------------------------------------
+
+describe("repoUrlToSlug", () => {
+	it("handles HTTPS URL with .git suffix", () => {
+		expect(repoUrlToSlug("https://github.com/owner/repo.git")).toBe("owner__repo");
+	});
+
+	it("handles HTTPS URL without .git suffix", () => {
+		expect(repoUrlToSlug("https://github.com/owner/repo")).toBe("owner__repo");
+	});
+
+	it("handles SSH URL with .git suffix", () => {
+		expect(repoUrlToSlug("git@github.com:owner/repo.git")).toBe("owner__repo");
+	});
+
+	it("handles SSH URL without .git suffix", () => {
+		expect(repoUrlToSlug("git@github.com:owner/repo")).toBe("owner__repo");
+	});
+
+	it("handles HTTPS URL with different host", () => {
+		expect(repoUrlToSlug("https://gitlab.com/myorg/myproject.git")).toBe("myorg__myproject");
+	});
+
+	it("handles SSH URL with different host", () => {
+		expect(repoUrlToSlug("git@gitlab.com:myorg/myproject.git")).toBe("myorg__myproject");
+	});
+
+	it("falls back to hash for malformed URL", () => {
+		const result = repoUrlToSlug("not-a-url");
+		expect(result).toStartWith("_hash_");
+		expect(result.length).toBe(6 + 16); // "_hash_" + 16 hex chars
+	});
+
+	it("falls back to hash for URL with too many segments", () => {
+		const result = repoUrlToSlug("https://github.com/owner/repo/extra/path");
+		expect(result).toStartWith("_hash_");
+	});
+
+	it("produces deterministic hash for same input", () => {
+		const a = repoUrlToSlug("not-a-url");
+		const b = repoUrlToSlug("not-a-url");
+		expect(a).toBe(b);
+	});
+
+	it("produces different hashes for different inputs", () => {
+		const a = repoUrlToSlug("url-one");
+		const b = repoUrlToSlug("url-two");
+		expect(a).not.toBe(b);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// classifyError
+// ---------------------------------------------------------------------------
+
+describe("classifyError", () => {
+	it("returns null for success", () => {
+		expect(classifyError(makeResult({ status: "success" }))).toBeNull();
+	});
+
+	it("returns timeout for timeout status", () => {
+		expect(classifyError(makeResult({ status: "timeout" }))).toBe("timeout");
+	});
+
+	it("detects auth_error from summary", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "Authentication failed: 401" }))).toBe("auth_error");
+	});
+
+	it("detects auth_error from failureReason", () => {
+		expect(
+			classifyError(makeResult({ status: "failed", summary: "failed", failureReason: "permission denied" })),
+		).toBe("auth_error");
+	});
+
+	it("detects rate_limit", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "rate limit exceeded (429)" }))).toBe("rate_limit");
+	});
+
+	it("detects model_refusal", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "content policy violation refused" }))).toBe(
+			"model_refusal",
+		);
+	});
+
+	it("detects no_changes", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "no changes needed, nothing to commit" }))).toBe(
+			"no_changes",
+		);
+	});
+
+	it("detects build_failure", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "compilation error in src/main.ts" }))).toBe(
+			"build_failure",
+		);
+	});
+
+	it("detects test_failure", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "3 tests fail in suite" }))).toBe("test_failure");
+	});
+
+	it("returns unknown for unrecognized failure", () => {
+		expect(classifyError(makeResult({ status: "failed", summary: "something went wrong" }))).toBe("unknown");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildLearningEntry
+// ---------------------------------------------------------------------------
+
+describe("buildLearningEntry", () => {
+	it("builds entry from successful result", () => {
+		const result = makeResult();
+		const entry = buildLearningEntry(result);
+		expect(entry.version).toBe("fixbot.learning/v1");
+		expect(entry.jobId).toBe("job-1");
+		expect(entry.taskClass).toBe("fix_ci");
+		expect(entry.status).toBe("success");
+		expect(entry.errorCategory).toBeNull();
+		expect(entry.summary).toBe("Fixed the CI build.");
+		expect(entry.durationMs).toBe(120000);
+	});
+
+	it("truncates summary exceeding 200 chars", () => {
+		const longSummary = "A".repeat(250);
+		const result = makeResult({ summary: longSummary });
+		const entry = buildLearningEntry(result);
+		expect(entry.summary.length).toBe(200);
+		expect(entry.summary).toEndWith("...");
+	});
+
+	it("preserves summary at exactly 200 chars", () => {
+		const exactSummary = "B".repeat(200);
+		const result = makeResult({ summary: exactSummary });
+		const entry = buildLearningEntry(result);
+		expect(entry.summary).toBe(exactSummary);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// appendLearning / readLearnings
+// ---------------------------------------------------------------------------
+
+describe("appendLearning / readLearnings", () => {
+	const testRepoUrl = `https://github.com/fixbot-test-${Date.now()}/learnings-test.git`;
+
+	afterEach(() => cleanupRepoDir(testRepoUrl));
+
+	it("reads empty array when no file exists", () => {
+		const uniqueUrl = `https://github.com/nonexistent-${Date.now()}/repo.git`;
+		const entries = readLearnings(uniqueUrl);
+		expect(entries).toEqual([]);
+		cleanupRepoDir(uniqueUrl);
+	});
+
+	it("appends and reads back entries", () => {
+		const entry1 = makeEntry({ jobId: "j1" });
+		const entry2 = makeEntry({ jobId: "j2", status: "failed", errorCategory: "timeout" });
+
+		appendLearning(testRepoUrl, entry1);
+		appendLearning(testRepoUrl, entry2);
+
+		const entries = readLearnings(testRepoUrl);
+		expect(entries).toHaveLength(2);
+		expect(entries[0].jobId).toBe("j1");
+		expect(entries[1].jobId).toBe("j2");
+		expect(entries[1].errorCategory).toBe("timeout");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// rotateLearnings
+// ---------------------------------------------------------------------------
+
+describe("rotateLearnings", () => {
+	const testRepoUrl = `https://github.com/fixbot-test-${Date.now()}/rotate-test.git`;
+
+	afterEach(() => cleanupRepoDir(testRepoUrl));
+
+	it("does nothing when under limit", () => {
+		for (let i = 0; i < 5; i++) {
+			appendLearning(testRepoUrl, makeEntry({ jobId: `j${i}` }));
+		}
+		rotateLearnings(testRepoUrl);
+		expect(readLearnings(testRepoUrl)).toHaveLength(5);
+	});
+
+	it("trims to 100 entries when over limit", () => {
+		for (let i = 0; i < 105; i++) {
+			appendLearning(testRepoUrl, makeEntry({ jobId: `j${i}` }));
+		}
+		expect(readLearnings(testRepoUrl)).toHaveLength(105);
+		rotateLearnings(testRepoUrl);
+		const after = readLearnings(testRepoUrl);
+		expect(after).toHaveLength(100);
+		// Should keep the most recent (last 100)
+		expect(after[0].jobId).toBe("j5");
+		expect(after[99].jobId).toBe("j104");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// detectPatterns
+// ---------------------------------------------------------------------------
+
+describe("detectPatterns", () => {
+	it("returns empty for fewer than 2 entries", () => {
+		expect(detectPatterns([makeEntry()])).toEqual([]);
+		expect(detectPatterns([])).toEqual([]);
+	});
+
+	it("flags majority failures", () => {
+		const entries = [
+			makeEntry({ status: "failed", errorCategory: "unknown" }),
+			makeEntry({ status: "failed", errorCategory: "unknown" }),
+			makeEntry({ status: "success" }),
+		];
+		const patterns = detectPatterns(entries);
+		expect(patterns.some((p) => p.message.includes("2/3 recent jobs failed"))).toBe(true);
+	});
+
+	it("flags recurring error category", () => {
+		const entries = [
+			makeEntry({ status: "failed", errorCategory: "auth_error" }),
+			makeEntry({ status: "failed", errorCategory: "auth_error" }),
+			makeEntry({ status: "failed", errorCategory: "auth_error" }),
+			makeEntry({ status: "success" }),
+		];
+		const patterns = detectPatterns(entries);
+		expect(patterns.some((p) => p.message.includes("Recurring auth_error"))).toBe(true);
+	});
+
+	it("flags slowing trend", () => {
+		const entries = [
+			makeEntry({ durationMs: 60000 }),
+			makeEntry({ durationMs: 60000 }),
+			makeEntry({ durationMs: 180000 }),
+			makeEntry({ durationMs: 180000 }),
+		];
+		const patterns = detectPatterns(entries);
+		expect(patterns.some((p) => p.message.includes("trending slower"))).toBe(true);
+	});
+
+	it("does not flag when durations are similar", () => {
+		const entries = [
+			makeEntry({ durationMs: 60000 }),
+			makeEntry({ durationMs: 60000 }),
+			makeEntry({ durationMs: 65000 }),
+			makeEntry({ durationMs: 70000 }),
+		];
+		const patterns = detectPatterns(entries);
+		expect(patterns.some((p) => p.message.includes("trending slower"))).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatLearningsContext
+// ---------------------------------------------------------------------------
+
+describe("formatLearningsContext", () => {
+	const testRepoUrl = `https://github.com/fixbot-test-${Date.now()}/format-test.git`;
+
+	afterEach(() => cleanupRepoDir(testRepoUrl));
+
+	it("returns undefined when no learnings exist", () => {
+		const uniqueUrl = `https://github.com/fixbot-test-${Date.now()}/empty.git`;
+		const result = formatLearningsContext(uniqueUrl);
+		expect(result).toBeUndefined();
+		cleanupRepoDir(uniqueUrl);
+	});
+
+	it("formats recent entries as markdown", () => {
+		appendLearning(testRepoUrl, makeEntry({ jobId: "j1", summary: "Fixed CI" }));
+		appendLearning(
+			testRepoUrl,
+			makeEntry({ jobId: "j2", status: "failed", errorCategory: "timeout", summary: "Timed out" }),
+		);
+
+		const context = formatLearningsContext(testRepoUrl);
+		expect(context).toBeDefined();
+		expect(context!).toContain("## Recent Job History");
+		expect(context!).toContain("OK fix_ci");
+		expect(context!).toContain("FAIL fix_ci");
+		expect(context!).toContain("[timeout]");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordLearning
+// ---------------------------------------------------------------------------
+
+describe("recordLearning", () => {
+	const testRepoUrl = `https://github.com/fixbot-test-${Date.now()}/record-test.git`;
+
+	afterEach(() => cleanupRepoDir(testRepoUrl));
+
+	it("records a learning entry safely", () => {
+		const result = makeResult({ repo: { url: testRepoUrl, baseBranch: "main" } });
+		recordLearning(result);
+		const entries = readLearnings(testRepoUrl);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].jobId).toBe("job-1");
+	});
+
+	it("does not throw on error, logs warning", () => {
+		const warnings: string[] = [];
+		const logger = { warn: (msg: string) => warnings.push(msg) };
+
+		const result = makeResult({ repo: { url: testRepoUrl, baseBranch: "main" } });
+		// Should not throw
+		expect(() => recordLearning(result, logger)).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

- **JSONL storage**: Per-repo learning entries stored in `~/.fixbot/repos/{owner}__{repo}/learnings.jsonl` with automatic rotation at 100 entries
- **Error classification**: Automatic categorization of job failures into 8 categories (timeout, auth_error, rate_limit, model_refusal, no_changes, build_failure, test_failure, unknown)
- **Pattern detection**: Analyzes recent job history to surface recurring failure patterns, majority-failure alerts, and performance degradation trends
- **Context injection**: `formatLearningsContext()` renders recent job history as markdown suitable for agent prompt injection
- **Runner integration**: `recordLearning()` called after every job completion, safe (never throws)

## Files changed

- **NEW** `packages/fixbot/src/learnings.ts` -- full learnings module (record, read, rotate, classify, detect patterns, format context)
- **NEW** `packages/fixbot/test/learnings.test.ts` -- 36 tests covering all public APIs
- **MODIFIED** `packages/fixbot/src/types.ts` -- added `LEARNING_ENTRY_VERSION_V1`, `ERROR_CATEGORIES`, `ErrorCategory`, `LearningEntryV1`
- **MODIFIED** `packages/fixbot/src/runner.ts` -- added `recordLearning` call after job completion, exported `formatDuration`

## Test plan

- [x] `bun test test/learnings.test.ts` -- 36 tests pass (repoUrlToSlug, classifyError, buildLearningEntry, appendLearning/readLearnings, rotateLearnings, detectPatterns, formatLearningsContext, recordLearning)

Closes #21