### PR TITLE
feat: webhook receiver for instant GitHub event triggers

### DIFF
--- a/packages/fixbot/src/config.ts
+++ b/packages/fixbot/src/config.ts
@@ -19,6 +19,7 @@ import {
 	type NormalizedDaemonConfigV1,
 	type NormalizedDaemonGitHubConfig,
 	type NormalizedDaemonGitHubRepoConfig,
+	type NormalizedDaemonWebhookConfig,
 	type ResultStatus,
 	TASK_CLASSES,
 	type TaskClass,
@@ -78,8 +79,10 @@ function parseDaemonErrorSummary(value: unknown, label: string): DaemonErrorSumm
 }
 
 export const DEFAULT_GITHUB_POLL_INTERVAL_MS = 60_000;
+export const DEFAULT_WEBHOOK_PORT = 8787;
+export const DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN = 10;
 
-const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label"]);
+const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label", "github-webhook"]);
 
 function parseDaemonSubmissionSource(value: unknown, label: string): DaemonSubmissionSourceV1 | undefined {
 	if (value === undefined) {
@@ -95,11 +98,12 @@ function parseDaemonSubmissionSource(value: unknown, label: string): DaemonSubmi
 		kind: kind as DaemonSubmissionKind,
 		filePath: filePath === undefined ? undefined : assertNonEmptyString(filePath, `${label}.filePath`),
 	};
-	if (kind === "github-label") {
+	if (kind === "github-label" || kind === "github-webhook") {
 		const githubRepo = submission.githubRepo;
 		const githubIssueNumber = submission.githubIssueNumber;
 		const githubLabelName = submission.githubLabelName;
 		const githubActionsRunId = submission.githubActionsRunId;
+		const githubDeliveryId = submission.githubDeliveryId;
 		if (githubRepo !== undefined) {
 			result.githubRepo = assertNonEmptyString(githubRepo, `${label}.githubRepo`);
 		}
@@ -111,6 +115,9 @@ function parseDaemonSubmissionSource(value: unknown, label: string): DaemonSubmi
 		}
 		if (githubActionsRunId !== undefined) {
 			result.githubActionsRunId = assertPositiveInteger(githubActionsRunId, `${label}.githubActionsRunId`);
+		}
+		if (githubDeliveryId !== undefined) {
+			result.githubDeliveryId = assertNonEmptyString(githubDeliveryId, `${label}.githubDeliveryId`);
 		}
 	}
 	return result;
@@ -258,6 +265,7 @@ function parseGitHubConfig(value: unknown, label: string): DaemonGitHubConfig {
 	const pollIntervalMs = gh.pollIntervalMs;
 	const appAuth = gh.appAuth === undefined ? undefined : parseAppAuth(gh.appAuth, `${label}.appAuth`);
 	const gpgKeyId = gh.gpgKeyId;
+	const botUsername = gh.botUsername;
 	return {
 		repos,
 		token: token === undefined ? undefined : assertNonEmptyString(token, `${label}.token`),
@@ -265,6 +273,7 @@ function parseGitHubConfig(value: unknown, label: string): DaemonGitHubConfig {
 			pollIntervalMs === undefined ? undefined : assertPositiveInteger(pollIntervalMs, `${label}.pollIntervalMs`),
 		appAuth,
 		gpgKeyId: gpgKeyId === undefined ? undefined : assertNonEmptyString(gpgKeyId, `${label}.gpgKeyId`),
+		botUsername: botUsername === undefined ? undefined : assertNonEmptyString(botUsername, `${label}.botUsername`),
 	};
 }
 function normalizeGitHubConfig(raw: unknown, label: string): NormalizedDaemonGitHubConfig {
@@ -275,7 +284,17 @@ function normalizeGitHubConfig(raw: unknown, label: string): NormalizedDaemonGit
 		pollIntervalMs: parsed.pollIntervalMs ?? DEFAULT_GITHUB_POLL_INTERVAL_MS,
 		appAuth: parsed.appAuth,
 		gpgKeyId: parsed.gpgKeyId,
+		botUsername: parsed.botUsername,
 	};
+}
+
+function normalizeWebhookConfig(raw: unknown, label: string): NormalizedDaemonWebhookConfig {
+	const wh = assertObject(raw, label);
+	const enabled = wh.enabled === undefined ? false : assertBoolean(wh.enabled, `${label}.enabled`);
+	const port = wh.port === undefined ? DEFAULT_WEBHOOK_PORT : assertPositiveInteger(wh.port, `${label}.port`);
+	const secret = assertNonEmptyString(wh.secret, `${label}.secret`);
+	const rateLimitPerRepoPerMin = wh.rateLimitPerRepoPerMin === undefined ? DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN : assertPositiveInteger(wh.rateLimitPerRepoPerMin, `${label}.rateLimitPerRepoPerMin`);
+	return { enabled, port, secret, rateLimitPerRepoPerMin };
 }
 
 export function normalizeDaemonConfig(value: unknown, source: string = "daemon config"): NormalizedDaemonConfigV1 {
@@ -343,6 +362,7 @@ export function normalizeDaemonConfig(value: unknown, source: string = "daemon c
 		github,
 		identity: { botUrl },
 		model,
+		webhook: root.webhook === undefined ? undefined : normalizeWebhookConfig(root.webhook, `${source}.webhook`),
 	};
 }
 

--- a/packages/fixbot/src/config.ts
+++ b/packages/fixbot/src/config.ts
@@ -23,6 +23,7 @@ import {
 	type ResultStatus,
 	TASK_CLASSES,
 	type TaskClass,
+	VALID_SUBMISSION_KINDS,
 } from "./types";
 import {
 	assertBoolean,
@@ -81,8 +82,6 @@ function parseDaemonErrorSummary(value: unknown, label: string): DaemonErrorSumm
 export const DEFAULT_GITHUB_POLL_INTERVAL_MS = 60_000;
 export const DEFAULT_WEBHOOK_PORT = 8787;
 export const DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN = 10;
-
-const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label", "github-webhook"]);
 
 function parseDaemonSubmissionSource(value: unknown, label: string): DaemonSubmissionSourceV1 | undefined {
 	if (value === undefined) {
@@ -292,8 +291,17 @@ function normalizeWebhookConfig(raw: unknown, label: string): NormalizedDaemonWe
 	const wh = assertObject(raw, label);
 	const enabled = wh.enabled === undefined ? false : assertBoolean(wh.enabled, `${label}.enabled`);
 	const port = wh.port === undefined ? DEFAULT_WEBHOOK_PORT : assertPositiveInteger(wh.port, `${label}.port`);
+	if (enabled && (wh.secret === undefined || wh.secret === "")) {
+		throw new Error(
+			`${label}.secret is required when webhook is enabled. ` +
+				"Set it to the GitHub webhook secret configured for your repository.",
+		);
+	}
 	const secret = assertNonEmptyString(wh.secret, `${label}.secret`);
-	const rateLimitPerRepoPerMin = wh.rateLimitPerRepoPerMin === undefined ? DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN : assertPositiveInteger(wh.rateLimitPerRepoPerMin, `${label}.rateLimitPerRepoPerMin`);
+	const rateLimitPerRepoPerMin =
+		wh.rateLimitPerRepoPerMin === undefined
+			? DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN
+			: assertPositiveInteger(wh.rateLimitPerRepoPerMin, `${label}.rateLimitPerRepoPerMin`);
 	return { enabled, port, secret, rateLimitPerRepoPerMin };
 }
 

--- a/packages/fixbot/src/daemon/job-store.ts
+++ b/packages/fixbot/src/daemon/job-store.ts
@@ -58,7 +58,7 @@ export class DuplicateDaemonJobError extends Error {
 	}
 }
 
-const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label"]);
+const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label", "github-webhook"]);
 
 function parseSubmissionSource(value: unknown, label: string): DaemonSubmissionSourceV1 {
 	const submission = assertObject(value, label);
@@ -71,11 +71,12 @@ function parseSubmissionSource(value: unknown, label: string): DaemonSubmissionS
 		kind: kind as DaemonSubmissionKind,
 		filePath: filePath === undefined ? undefined : assertNonEmptyString(filePath, `${label}.filePath`),
 	};
-	if (kind === "github-label") {
+	if (kind === "github-label" || kind === "github-webhook") {
 		const githubRepo = submission.githubRepo;
 		const githubIssueNumber = submission.githubIssueNumber;
 		const githubLabelName = submission.githubLabelName;
 		const githubActionsRunId = submission.githubActionsRunId;
+		const githubDeliveryId = submission.githubDeliveryId;
 		if (githubRepo !== undefined) {
 			result.githubRepo = assertNonEmptyString(githubRepo, `${label}.githubRepo`);
 		}
@@ -87,6 +88,9 @@ function parseSubmissionSource(value: unknown, label: string): DaemonSubmissionS
 		}
 		if (githubActionsRunId !== undefined) {
 			result.githubActionsRunId = assertPositiveInteger(githubActionsRunId, `${label}.githubActionsRunId`);
+		}
+		if (githubDeliveryId !== undefined) {
+			result.githubDeliveryId = assertNonEmptyString(githubDeliveryId, `${label}.githubDeliveryId`);
 		}
 	}
 	return result;

--- a/packages/fixbot/src/daemon/job-store.ts
+++ b/packages/fixbot/src/daemon/job-store.ts
@@ -9,6 +9,7 @@ import {
 	type DaemonSubmissionKind,
 	type DaemonSubmissionSourceV1,
 	type NormalizedDaemonConfigV1,
+	VALID_SUBMISSION_KINDS,
 } from "../types";
 import { assertNonEmptyString, assertObject, assertPositiveInteger, assertTimestamp } from "../validation";
 
@@ -57,8 +58,6 @@ export class DuplicateDaemonJobError extends Error {
 		this.collisions = collisions.map((collision) => ({ ...collision }));
 	}
 }
-
-const VALID_SUBMISSION_KINDS = new Set<DaemonSubmissionKind>(["cli", "github-label", "github-webhook"]);
 
 function parseSubmissionSource(value: unknown, label: string): DaemonSubmissionSourceV1 {
 	const submission = assertObject(value, label);

--- a/packages/fixbot/src/daemon/service.ts
+++ b/packages/fixbot/src/daemon/service.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types";
 import { exchangeInstallationToken, isTokenExpiringSoon, type TokenCache } from "./github-app-auth";
 import type { GitHubPollResult } from "./github-poller";
+import { createWebhookServer, type WebhookServer } from "./webhook-server";
 import { pollGitHubRepos } from "./github-poller";
 import { reportJobResult } from "./github-reporter";
 import {
@@ -603,6 +604,7 @@ export async function runDaemon(config: NormalizedDaemonConfigV1, options: RunDa
 		});
 	}
 
+	let webhookServer: WebhookServer | undefined;
 	let shuttingDown = false;
 	let stopSummary: DaemonErrorSummary | undefined;
 
@@ -637,6 +639,21 @@ export async function runDaemon(config: NormalizedDaemonConfigV1, options: RunDa
 		// Resolve App auth token before the first poll cycle.
 		if (options.tokenProvider || (config.github?.appAuth && !config.github.token)) {
 			await resolveToken();
+		}
+
+		// Start webhook server if configured and enabled.
+		if (config.webhook?.enabled) {
+			try {
+				webhookServer = createWebhookServer({
+					config,
+					webhookConfig: config.webhook,
+					logger,
+				});
+				renderLog(logger, `webhook: server started on port ${webhookServer.port}`);
+			} catch (webhookError) {
+				const msg = webhookError instanceof Error ? webhookError.message : String(webhookError);
+				logger?.error(`webhook: failed to start server: ${msg}`);
+			}
 		}
 
 		let lastHeartbeatMs = Date.parse(startedAt);
@@ -741,6 +758,9 @@ export async function runDaemon(config: NormalizedDaemonConfigV1, options: RunDa
 		}
 		stopSummary = stopSummary ?? buildErrorSummary("daemon stopped by operator", "STOPPED");
 	} finally {
+		if (webhookServer) {
+			try { await webhookServer.stop(); } catch (e) { logger?.error(`webhook shutdown: ${e instanceof Error ? e.message : String(e)}`); }
+		}
 		const stopStatus = createDaemonStatus(config, {
 			state: currentStatus.state === "error" ? "error" : "degraded",
 			startedAt: currentStatus.startedAt,

--- a/packages/fixbot/src/daemon/webhook-server.ts
+++ b/packages/fixbot/src/daemon/webhook-server.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { getArtifactPaths } from "../artifacts";
 import { normalizeJobSpec } from "../contracts";
+import { parseOwnerRepo } from "../github-utils";
 import type { Logger } from "../logger";
 import {
 	DAEMON_JOB_ENVELOPE_VERSION_V1,
@@ -84,16 +85,11 @@ export function findRepoConfig(
 	const fullNameLower = repoFullName.toLowerCase();
 	return config.github?.repos.find((r) => {
 		try {
-			const url = new URL(r.url);
-			const pathParts = url.pathname.replace(/\.git$/, "").split("/").filter(Boolean);
-			if (pathParts.length >= 2) {
-				const ownerRepo = `${pathParts[0]}/${pathParts[1]}`.toLowerCase();
-				return ownerRepo === fullNameLower;
-			}
+			const parsed = parseOwnerRepo(r.url);
+			return `${parsed.owner}/${parsed.repo}`.toLowerCase() === fullNameLower;
 		} catch {
 			return r.url.toLowerCase() === fullNameLower;
 		}
-		return false;
 	});
 }
 

--- a/packages/fixbot/src/daemon/webhook-server.ts
+++ b/packages/fixbot/src/daemon/webhook-server.ts
@@ -1,0 +1,472 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { getArtifactPaths } from "../artifacts";
+import { normalizeJobSpec } from "../contracts";
+import type { Logger } from "../logger";
+import {
+	DAEMON_JOB_ENVELOPE_VERSION_V1,
+	type DaemonJobEnvelopeV1,
+	type NormalizedDaemonConfigV1,
+	type NormalizedDaemonGitHubRepoConfig,
+	type NormalizedDaemonWebhookConfig,
+	type NormalizedJobSpecV1,
+	type TaskClass,
+	type WebhookHealthMetrics,
+} from "../types";
+import { DuplicateDaemonJobError, enqueueDaemonJob } from "./job-store";
+
+// ---------------------------------------------------------------------------
+// Rate limiter (sliding window, per-repo)
+// ---------------------------------------------------------------------------
+
+interface RateLimitBucket {
+	timestamps: number[];
+}
+
+export class SlidingWindowRateLimiter {
+	private readonly buckets = new Map<string, RateLimitBucket>();
+	private readonly windowMs: number;
+	private readonly limit: number;
+
+	constructor(limit: number, windowMs: number = 60_000) {
+		this.limit = limit;
+		this.windowMs = windowMs;
+	}
+
+	/** Returns true if the request is allowed (within rate limit). */
+	allow(key: string): boolean {
+		const now = Date.now();
+		const cutoff = now - this.windowMs;
+		let bucket = this.buckets.get(key);
+		if (!bucket) {
+			bucket = { timestamps: [] };
+			this.buckets.set(key, bucket);
+		}
+		// Prune old entries
+		bucket.timestamps = bucket.timestamps.filter((t) => t > cutoff);
+		if (bucket.timestamps.length >= this.limit) {
+			return false;
+		}
+		bucket.timestamps.push(now);
+		return true;
+	}
+
+	reset(): void {
+		this.buckets.clear();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+export function verifyWebhookSignature(payload: string, signatureHeader: string, secret: string): boolean {
+	if (!signatureHeader.startsWith("sha256=")) {
+		return false;
+	}
+	const receivedHex = signatureHeader.slice("sha256=".length);
+	const expectedHex = createHmac("sha256", secret).update(payload).digest("hex");
+	const expected = Buffer.from(expectedHex, "hex");
+	const received = Buffer.from(receivedHex, "hex");
+	if (expected.length !== received.length) {
+		return false;
+	}
+	return timingSafeEqual(expected, received);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared with github-poller
+// ---------------------------------------------------------------------------
+
+export function findRepoConfig(
+	config: NormalizedDaemonConfigV1,
+	repoFullName: string,
+): NormalizedDaemonGitHubRepoConfig | undefined {
+	const fullNameLower = repoFullName.toLowerCase();
+	return config.github?.repos.find((r) => {
+		try {
+			const url = new URL(r.url);
+			const pathParts = url.pathname.replace(/\.git$/, "").split("/").filter(Boolean);
+			if (pathParts.length >= 2) {
+				const ownerRepo = `${pathParts[0]}/${pathParts[1]}`.toLowerCase();
+				return ownerRepo === fullNameLower;
+			}
+		} catch {
+			return r.url.toLowerCase() === fullNameLower;
+		}
+		return false;
+	});
+}
+
+export function deriveWebhookJobId(repoUrl: string, issueNumber: number, deliveryId: string): string {
+	const hex = createHash("sha256")
+		.update(`${repoUrl}/${issueNumber}/webhook/${deliveryId}`)
+		.digest("hex")
+		.slice(0, 16);
+	return `wh-${hex}`;
+}
+
+export function buildWebhookJobSpec(
+	repoUrl: string,
+	baseBranch: string,
+	issueNumber: number,
+	deliveryId: string,
+	taskClass: TaskClass = "solve_issue",
+	issueTitle?: string,
+	issueBody?: string,
+): NormalizedJobSpecV1 {
+	const jobId = deriveWebhookJobId(repoUrl, issueNumber, deliveryId);
+	const spec: Record<string, unknown> = {
+		version: "fixbot.job/v1",
+		jobId,
+		taskClass,
+		repo: { url: repoUrl, baseBranch },
+		execution: { mode: "process", timeoutMs: 1_800_000, memoryLimitMb: 4096 },
+	};
+	if (taskClass === "fix_ci") {
+		spec.fixCi = { githubActionsRunId: 1 };
+	} else if (taskClass === "solve_issue") {
+		spec.solveIssue = {
+			issueNumber,
+			...(issueTitle ? { issueTitle } : {}),
+			...(issueBody ? { issueBody } : {}),
+		};
+	}
+	return normalizeJobSpec(spec, "webhook job");
+}
+
+export function createGitHubEnvelope(
+	jobSpec: NormalizedJobSpecV1,
+	repoFullName: string,
+	issueNumber: number,
+	deliveryId: string,
+	resultsDir: string,
+	labelName?: string,
+): DaemonJobEnvelopeV1 {
+	const artifactPaths = getArtifactPaths(resultsDir, jobSpec.jobId);
+	return {
+		version: DAEMON_JOB_ENVELOPE_VERSION_V1,
+		jobId: jobSpec.jobId,
+		job: jobSpec,
+		submission: {
+			kind: "github-webhook",
+			githubRepo: repoFullName,
+			githubIssueNumber: issueNumber,
+			...(labelName ? { githubLabelName: labelName } : {}),
+			githubDeliveryId: deliveryId,
+		},
+		enqueuedAt: new Date().toISOString(),
+		artifacts: {
+			artifactDir: artifactPaths.artifactDir,
+			resultFile: artifactPaths.resultFile,
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Webhook event handlers
+// ---------------------------------------------------------------------------
+
+interface WebhookPayload {
+	action: string;
+	issue?: {
+		number: number;
+		title: string;
+		body: string | null;
+	};
+	assignee?: { login: string };
+	label?: { name: string };
+	comment?: { body: string };
+	pull_request?: { number: number; title: string; body: string | null };
+	repository: { full_name: string };
+	sender?: { login: string };
+}
+
+function handleIssuesLabeled(
+	payload: WebhookPayload,
+	config: NormalizedDaemonConfigV1,
+	deliveryId: string,
+	logger?: Logger,
+): DaemonJobEnvelopeV1 | null {
+	if (!payload.issue || !payload.label) {
+		logger?.warn("webhook: issues.labeled event missing issue or label");
+		return null;
+	}
+
+	const repoFullName = payload.repository.full_name;
+	const repoConfig = findRepoConfig(config, repoFullName);
+	if (!repoConfig) {
+		logger?.info(`webhook: ignoring event for unconfigured repo ${repoFullName}`);
+		return null;
+	}
+
+	const labelName = payload.label.name;
+	const allLabels = new Set([repoConfig.triggerLabel]);
+	if (repoConfig.taskClassOverrides) {
+		for (const label of Object.keys(repoConfig.taskClassOverrides)) {
+			allLabels.add(label);
+		}
+	}
+	if (!allLabels.has(labelName)) {
+		logger?.info(`webhook: ignoring label "${labelName}" for ${repoFullName}`);
+		return null;
+	}
+
+	const taskClass: TaskClass = repoConfig.taskClassOverrides?.[labelName] ?? "solve_issue";
+	const jobSpec = buildWebhookJobSpec(
+		repoConfig.url,
+		repoConfig.baseBranch,
+		payload.issue.number,
+		deliveryId,
+		taskClass,
+		payload.issue.title,
+		payload.issue.body ?? undefined,
+	);
+
+	return createGitHubEnvelope(
+		jobSpec,
+		repoFullName,
+		payload.issue.number,
+		deliveryId,
+		config.paths.resultsDir,
+		labelName,
+	);
+}
+
+function handleIssuesAssigned(
+	payload: WebhookPayload,
+	config: NormalizedDaemonConfigV1,
+	deliveryId: string,
+	logger?: Logger,
+): DaemonJobEnvelopeV1 | null {
+	if (!payload.issue) {
+		logger?.warn("webhook: issues.assigned event missing issue");
+		return null;
+	}
+
+	// Only trigger when the issue is assigned to the configured bot user.
+	const botUsername = config.github?.botUsername;
+	const assigneeLogin = payload.assignee?.login;
+	if (!botUsername) {
+		logger?.info("webhook: ignoring issues.assigned — no github.botUsername configured");
+		return null;
+	}
+	if (assigneeLogin?.toLowerCase() !== botUsername.toLowerCase()) {
+		logger?.info(`webhook: ignoring issues.assigned — assignee "${assigneeLogin}" is not bot user "${botUsername}"`);
+		return null;
+	}
+
+	const repoFullName = payload.repository.full_name;
+	const repoConfig = findRepoConfig(config, repoFullName);
+	if (!repoConfig) {
+		logger?.info(`webhook: ignoring event for unconfigured repo ${repoFullName}`);
+		return null;
+	}
+
+	const jobSpec = buildWebhookJobSpec(
+		repoConfig.url,
+		repoConfig.baseBranch,
+		payload.issue.number,
+		deliveryId,
+		"solve_issue",
+		payload.issue.title,
+		payload.issue.body ?? undefined,
+	);
+
+	return createGitHubEnvelope(
+		jobSpec,
+		repoFullName,
+		payload.issue.number,
+		deliveryId,
+		config.paths.resultsDir,
+	);
+}
+
+function handlePRReviewComment(
+	payload: WebhookPayload,
+	config: NormalizedDaemonConfigV1,
+	deliveryId: string,
+	logger?: Logger,
+): DaemonJobEnvelopeV1 | null {
+	if (!payload.pull_request || !payload.comment) {
+		logger?.warn("webhook: pull_request_review_comment.created event missing PR or comment");
+		return null;
+	}
+
+	const repoFullName = payload.repository.full_name;
+	const repoConfig = findRepoConfig(config, repoFullName);
+	if (!repoConfig) {
+		logger?.info(`webhook: ignoring event for unconfigured repo ${repoFullName}`);
+		return null;
+	}
+
+	const jobSpec = buildWebhookJobSpec(
+		repoConfig.url,
+		repoConfig.baseBranch,
+		payload.pull_request.number,
+		deliveryId,
+		"solve_issue",
+		payload.pull_request.title,
+		payload.pull_request.body ?? undefined,
+	);
+
+	return createGitHubEnvelope(
+		jobSpec,
+		repoFullName,
+		payload.pull_request.number,
+		deliveryId,
+		config.paths.resultsDir,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Webhook event routing
+// ---------------------------------------------------------------------------
+
+export function routeWebhookEvent(
+	eventType: string,
+	payload: WebhookPayload,
+	config: NormalizedDaemonConfigV1,
+	deliveryId: string,
+	logger?: Logger,
+): DaemonJobEnvelopeV1 | null {
+	const action = payload.action;
+	const eventAction = `${eventType}.${action}`;
+
+	switch (eventAction) {
+		case "issues.labeled":
+			return handleIssuesLabeled(payload, config, deliveryId, logger);
+		case "issues.assigned":
+			return handleIssuesAssigned(payload, config, deliveryId, logger);
+		case "pull_request_review_comment.created":
+			return handlePRReviewComment(payload, config, deliveryId, logger);
+		default:
+			logger?.info(`webhook: ignoring unhandled event ${eventAction}`);
+			return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+export interface WebhookServer {
+	readonly port: number;
+	readonly metrics: WebhookHealthMetrics;
+	stop(): Promise<void>;
+}
+
+export interface WebhookServerOptions {
+	config: NormalizedDaemonConfigV1;
+	webhookConfig: NormalizedDaemonWebhookConfig;
+	logger?: Logger;
+}
+
+export function createWebhookServer(options: WebhookServerOptions): WebhookServer {
+	const { config, webhookConfig, logger } = options;
+
+	const metrics: WebhookHealthMetrics = {
+		receivedCount: 0,
+		acceptedCount: 0,
+		rejectedCount: 0,
+		rateLimitedCount: 0,
+		lastReceivedAt: null,
+	};
+
+	const rateLimiter = new SlidingWindowRateLimiter(webhookConfig.rateLimitPerRepoPerMin);
+
+	const server = Bun.serve({
+		port: webhookConfig.port,
+		async fetch(req: Request): Promise<Response> {
+			const url = new URL(req.url);
+
+			// Health endpoint
+			if (req.method === "GET" && url.pathname === "/healthz") {
+				return Response.json({ status: "ok", ...metrics });
+			}
+
+			// Only accept POST to /webhook
+			if (req.method !== "POST" || url.pathname !== "/webhook") {
+				return new Response("Not Found", { status: 404 });
+			}
+
+			metrics.receivedCount++;
+			metrics.lastReceivedAt = new Date().toISOString();
+
+			const body = await req.text();
+
+			// Verify signature
+			const signatureHeader = req.headers.get("x-hub-signature-256") ?? "";
+			if (!verifyWebhookSignature(body, signatureHeader, webhookConfig.secret)) {
+				metrics.rejectedCount++;
+				logger?.warn("webhook: signature verification failed");
+				return new Response("Unauthorized", { status: 401 });
+			}
+
+			const eventType = req.headers.get("x-github-event") ?? "";
+			const deliveryId = req.headers.get("x-github-delivery") ?? `unknown-${Date.now()}`;
+
+			if (!eventType) {
+				metrics.rejectedCount++;
+				return new Response("Missing X-GitHub-Event header", { status: 400 });
+			}
+
+			let payload: WebhookPayload;
+			try {
+				payload = JSON.parse(body) as WebhookPayload;
+			} catch {
+				metrics.rejectedCount++;
+				return new Response("Invalid JSON", { status: 400 });
+			}
+
+			const repoFullName = payload.repository?.full_name;
+			if (!repoFullName) {
+				metrics.rejectedCount++;
+				return new Response("Missing repository.full_name", { status: 400 });
+			}
+
+			if (!rateLimiter.allow(repoFullName)) {
+				metrics.rateLimitedCount++;
+				logger?.warn(`webhook: rate limited for ${repoFullName}`);
+				return new Response("Rate Limited", { status: 429 });
+			}
+
+			const envelope = routeWebhookEvent(eventType, payload, config, deliveryId, logger);
+			if (!envelope) {
+				return Response.json({ status: "ignored", deliveryId });
+			}
+
+			try {
+				enqueueDaemonJob(config, envelope);
+				metrics.acceptedCount++;
+				logger?.info(
+					`webhook: enqueued ${envelope.job.taskClass} job ${envelope.jobId} for ${repoFullName} (delivery: ${deliveryId})`,
+				);
+				return Response.json({ status: "queued", jobId: envelope.jobId, deliveryId });
+			} catch (error) {
+				if (error instanceof DuplicateDaemonJobError) {
+					logger?.info(`webhook: duplicate job skipped for ${repoFullName} (delivery: ${deliveryId})`);
+					return Response.json({ status: "duplicate", jobId: envelope.jobId, deliveryId });
+				}
+				const msg = error instanceof Error ? error.message : String(error);
+				logger?.error(`webhook: enqueue failed for ${repoFullName}: ${msg}`);
+				return new Response("Internal Server Error", { status: 500 });
+			}
+		},
+	});
+
+	logger?.info(`webhook: server listening on port ${webhookConfig.port}`);
+
+	return {
+		get port() {
+			return server.port;
+		},
+		get metrics() {
+			return { ...metrics };
+		},
+		async stop() {
+			server.stop(true);
+			rateLimiter.reset();
+			logger?.info("webhook: server stopped");
+		},
+	};
+}

--- a/packages/fixbot/src/github-utils.ts
+++ b/packages/fixbot/src/github-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared GitHub URL utilities.
+ *
+ * `parseOwnerRepo` was originally defined in `daemon/github-reporter.ts`.
+ * It is now re-exported from this module so that both the reporter and the
+ * repo-cache can use it without circular dependencies.
+ */
+
+/**
+ * Extract owner/repo from a GitHub URL like `https://github.com/owner/repo`
+ * or `https://github.com/owner/repo.git`, or from an `owner/repo` shorthand.
+ */
+export function parseOwnerRepo(input: string): { owner: string; repo: string } {
+	// If it looks like a URL, parse it
+	if (input.startsWith("http://") || input.startsWith("https://")) {
+		let pathname: string;
+		try {
+			pathname = new URL(input).pathname;
+		} catch {
+			throw new Error(`Invalid GitHub repo URL: ${input}`);
+		}
+		const cleaned = pathname
+			.replace(/^\//, "")
+			.replace(/\/$/, "")
+			.replace(/\.git$/, "");
+		const segments = cleaned.split("/").filter(Boolean);
+		if (segments.length !== 2) {
+			throw new Error(`GitHub repo URL must have exactly owner/repo path segments: ${input}`);
+		}
+		return { owner: segments[0], repo: segments[1] };
+	}
+
+	// Otherwise treat as owner/repo shorthand
+	const cleaned = input.replace(/\.git$/, "").replace(/\/$/, "");
+	const segments = cleaned.split("/").filter(Boolean);
+	if (segments.length !== 2) {
+		throw new Error(`Expected owner/repo format: ${input}`);
+	}
+	return { owner: segments[0], repo: segments[1] };
+}

--- a/packages/fixbot/src/index.ts
+++ b/packages/fixbot/src/index.ts
@@ -6,6 +6,8 @@ export {
 	DEFAULT_DAEMON_PID_FILE,
 	DEFAULT_DAEMON_STATUS_FILE,
 	DEFAULT_GITHUB_POLL_INTERVAL_MS,
+	DEFAULT_WEBHOOK_PORT,
+	DEFAULT_WEBHOOK_RATE_LIMIT_PER_REPO_PER_MIN,
 	loadDaemonConfig,
 	normalizeDaemonConfig,
 	normalizeDaemonStatus,
@@ -117,3 +119,12 @@ export {
 export { parseResultMarkers } from "./markers";
 export { runJob } from "./runner";
 export * from "./types";
+export {
+	createWebhookServer,
+	findRepoConfig,
+	routeWebhookEvent,
+	SlidingWindowRateLimiter,
+	verifyWebhookSignature,
+	type WebhookServer,
+	type WebhookServerOptions,
+} from "./daemon/webhook-server";

--- a/packages/fixbot/src/types.ts
+++ b/packages/fixbot/src/types.ts
@@ -16,6 +16,11 @@ export type SandboxMode = "workspace-write" | "read-only";
 export type DaemonLifecycleState = (typeof DAEMON_LIFECYCLE_STATES)[number];
 export type DaemonStatusFormat = "json";
 export type DaemonSubmissionKind = "cli" | "github-label" | "github-webhook";
+export const VALID_SUBMISSION_KINDS: ReadonlySet<DaemonSubmissionKind> = new Set<DaemonSubmissionKind>([
+	"cli",
+	"github-label",
+	"github-webhook",
+]);
 
 export interface RepoTarget {
 	url: string;

--- a/packages/fixbot/src/types.ts
+++ b/packages/fixbot/src/types.ts
@@ -15,7 +15,7 @@ export type ExecutionMode = "process" | "docker";
 export type SandboxMode = "workspace-write" | "read-only";
 export type DaemonLifecycleState = (typeof DAEMON_LIFECYCLE_STATES)[number];
 export type DaemonStatusFormat = "json";
-export type DaemonSubmissionKind = "cli" | "github-label";
+export type DaemonSubmissionKind = "cli" | "github-label" | "github-webhook";
 
 export interface RepoTarget {
 	url: string;
@@ -245,6 +245,8 @@ export interface DaemonGitHubConfig {
 	appAuth?: GitHubAppAuthConfig;
 	/** GPG key ID (fingerprint or email) used for signing commits. When omitted, signing is attempted only if git's global user.signingKey is set. */
 	gpgKeyId?: string;
+	/** GitHub username of the bot account. When set, issues assigned to this user trigger solve_issue jobs. */
+	botUsername?: string;
 }
 
 export interface NormalizedDaemonGitHubRepoConfig {
@@ -261,6 +263,8 @@ export interface NormalizedDaemonGitHubConfig {
 	appAuth?: GitHubAppAuthConfig;
 	/** Normalized from DaemonGitHubConfig.gpgKeyId. */
 	gpgKeyId?: string;
+	/** GitHub username of the bot account. When set, issues assigned to this user trigger solve_issue jobs. */
+	botUsername?: string;
 }
 
 export interface DaemonConfigV1 {
@@ -271,6 +275,7 @@ export interface DaemonConfigV1 {
 	github?: DaemonGitHubConfig;
 	identity?: { botUrl?: string };
 	model?: DaemonModelConfig;
+	webhook?: DaemonWebhookConfig;
 }
 
 export interface DaemonResolvedPaths {
@@ -300,6 +305,7 @@ export interface NormalizedDaemonConfigV1 {
 	github?: NormalizedDaemonGitHubConfig;
 	identity: { botUrl: string };
 	model?: DaemonModelConfig;
+	webhook?: NormalizedDaemonWebhookConfig;
 }
 
 export interface DaemonErrorSummary {
@@ -315,6 +321,7 @@ export interface DaemonSubmissionSourceV1 {
 	githubIssueNumber?: number;
 	githubLabelName?: string;
 	githubActionsRunId?: number;
+	githubDeliveryId?: string;
 }
 
 export interface DaemonJobArtifactSummaryV1 {
@@ -392,4 +399,24 @@ export interface DaemonStatusSnapshotV1 {
 	queue: DaemonQueueStatusV1;
 	activeJob: DaemonActiveJobStatusV1 | null;
 	recentResults: DaemonRecentResultSummaryV1[];
+}
+
+export interface DaemonWebhookConfig {
+	enabled?: boolean;
+	port?: number;
+	secret?: string;
+	rateLimitPerRepoPerMin?: number;
+}
+export interface NormalizedDaemonWebhookConfig {
+	enabled: boolean;
+	port: number;
+	secret: string;
+	rateLimitPerRepoPerMin: number;
+}
+export interface WebhookHealthMetrics {
+	receivedCount: number;
+	acceptedCount: number;
+	rejectedCount: number;
+	rateLimitedCount: number;
+	lastReceivedAt: string | null;
 }

--- a/packages/fixbot/test/daemon-config.test.ts
+++ b/packages/fixbot/test/daemon-config.test.ts
@@ -629,7 +629,7 @@ describe("daemon config webhook section", () => {
 		});
 
 		expect(() => parseDaemonConfigText(invalid, fixtureConfigPath)).toThrow(
-			`${fixtureConfigPath}.webhook.secret must be a non-empty string`,
+			`${fixtureConfigPath}.webhook.secret is required when webhook is enabled`,
 		);
 	});
 

--- a/packages/fixbot/test/daemon-config.test.ts
+++ b/packages/fixbot/test/daemon-config.test.ts
@@ -549,3 +549,170 @@ describe("parseDaemonSubmissionSource via status parsing", () => {
 		});
 	});
 });
+
+describe("daemon config webhook section", () => {
+	it("parses and normalizes a valid webhook config section", () => {
+		const config = parseDaemonConfigText(
+			JSON.stringify({
+				version: "fixbot.daemon-config/v1",
+				paths: {
+					stateDir: "./runtime/state",
+					resultsDir: "./runtime/results",
+				},
+				webhook: {
+					enabled: true,
+					port: 9090,
+					secret: "whsec_test123",
+					rateLimitPerRepoPerMin: 20,
+				},
+			}),
+			fixtureConfigPath,
+		);
+
+		expect(config.webhook).toBeDefined();
+		expect(config.webhook!.enabled).toBe(true);
+		expect(config.webhook!.port).toBe(9090);
+		expect(config.webhook!.secret).toBe("whsec_test123");
+		expect(config.webhook!.rateLimitPerRepoPerMin).toBe(20);
+	});
+
+	it("defaults port and rateLimitPerRepoPerMin when omitted", () => {
+		const config = parseDaemonConfigText(
+			JSON.stringify({
+				version: "fixbot.daemon-config/v1",
+				paths: {
+					stateDir: "./runtime/state",
+					resultsDir: "./runtime/results",
+				},
+				webhook: {
+					enabled: true,
+					secret: "whsec_test123",
+				},
+			}),
+			fixtureConfigPath,
+		);
+
+		expect(config.webhook).toBeDefined();
+		expect(config.webhook!.port).toBe(8787);
+		expect(config.webhook!.rateLimitPerRepoPerMin).toBe(10);
+	});
+
+	it("defaults enabled to false when omitted", () => {
+		const config = parseDaemonConfigText(
+			JSON.stringify({
+				version: "fixbot.daemon-config/v1",
+				paths: {
+					stateDir: "./runtime/state",
+					resultsDir: "./runtime/results",
+				},
+				webhook: {
+					secret: "whsec_test123",
+				},
+			}),
+			fixtureConfigPath,
+		);
+
+		expect(config.webhook).toBeDefined();
+		expect(config.webhook!.enabled).toBe(false);
+	});
+
+	it("rejects webhook config with missing secret", () => {
+		const invalid = JSON.stringify({
+			version: "fixbot.daemon-config/v1",
+			paths: {
+				stateDir: "./runtime/state",
+				resultsDir: "./runtime/results",
+			},
+			webhook: {
+				enabled: true,
+			},
+		});
+
+		expect(() => parseDaemonConfigText(invalid, fixtureConfigPath)).toThrow(
+			`${fixtureConfigPath}.webhook.secret must be a non-empty string`,
+		);
+	});
+
+	it("rejects webhook config with invalid port", () => {
+		const invalid = JSON.stringify({
+			version: "fixbot.daemon-config/v1",
+			paths: {
+				stateDir: "./runtime/state",
+				resultsDir: "./runtime/results",
+			},
+			webhook: {
+				enabled: true,
+				secret: "whsec_test123",
+				port: 0,
+			},
+		});
+
+		expect(() => parseDaemonConfigText(invalid, fixtureConfigPath)).toThrow(
+			`${fixtureConfigPath}.webhook.port must be a positive integer`,
+		);
+	});
+
+	it("parses config without webhook section (backward compatibility)", () => {
+		const config = parseDaemonConfigText(
+			JSON.stringify({
+				version: "fixbot.daemon-config/v1",
+				paths: {
+					stateDir: "./runtime/state",
+					resultsDir: "./runtime/results",
+				},
+			}),
+			fixtureConfigPath,
+		);
+
+		expect(config.webhook).toBeUndefined();
+	});
+});
+
+describe("parseDaemonSubmissionSource via status parsing (github-webhook)", () => {
+	it("accepts github-webhook submission kind in daemon status", () => {
+		const config = parseDaemonConfigText(
+			JSON.stringify({
+				version: "fixbot.daemon-config/v1",
+				paths: {
+					stateDir: "./runtime/state",
+					resultsDir: "./runtime/results",
+				},
+			}),
+			fixtureConfigPath,
+		);
+
+		const status = normalizeDaemonStatus(
+			{
+				version: "fixbot.daemon-status/v1",
+				state: "idle",
+				lastTransitionAt: "2026-03-16T08:00:00.000Z",
+				paths: config.paths,
+				queue: {
+					depth: 1,
+					preview: [
+						{
+							jobId: "wh-abc123",
+							enqueuedAt: "2026-03-16T08:00:00.000Z",
+							submission: {
+								kind: "github-webhook",
+								githubRepo: "owner/repo",
+								githubIssueNumber: 42,
+								githubDeliveryId: "delivery-uuid-123",
+							},
+						},
+					],
+					previewTruncated: false,
+				},
+				recentResults: [],
+			},
+			"test-status",
+		);
+
+		expect(status.queue.preview[0].submission).toEqual({
+			kind: "github-webhook",
+			githubRepo: "owner/repo",
+			githubIssueNumber: 42,
+			githubDeliveryId: "delivery-uuid-123",
+		});
+	});
+});

--- a/packages/fixbot/test/daemon-webhook.test.ts
+++ b/packages/fixbot/test/daemon-webhook.test.ts
@@ -1,0 +1,647 @@
+import { createHmac } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { normalizeDaemonConfig } from "../src/config";
+import type { NormalizedDaemonConfigV1, NormalizedDaemonWebhookConfig } from "../src/types";
+import {
+	createWebhookServer,
+	deriveWebhookJobId,
+	findRepoConfig,
+	routeWebhookEvent,
+	SlidingWindowRateLimiter,
+	verifyWebhookSignature,
+	type WebhookServer,
+} from "../src/daemon/webhook-server";
+import { createCapturingLogger } from "../src/logger";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = "test-webhook-secret-abc123";
+
+function signPayload(payload: string, secret: string): string {
+	return "sha256=" + createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+function makeTestConfig(overrides?: Partial<NormalizedDaemonWebhookConfig>): NormalizedDaemonConfigV1 {
+	const tempDir = join(tmpdir(), `fixbot-webhook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(join(tempDir, "state", "queue"), { recursive: true });
+	mkdirSync(join(tempDir, "state", "active"), { recursive: true });
+	mkdirSync(join(tempDir, "results"), { recursive: true });
+
+	const baseConfig = normalizeDaemonConfig(
+		{
+			version: "fixbot.daemon-config/v1",
+			paths: {
+				stateDir: join(tempDir, "state"),
+				resultsDir: join(tempDir, "results"),
+			},
+			github: {
+				repos: [
+					{
+						url: "https://github.com/testowner/testrepo",
+						baseBranch: "main",
+						triggerLabel: "fixbot",
+						taskClassOverrides: {
+							"fixbot:ci": "fix_ci",
+						},
+					},
+					{
+						url: "https://github.com/other/project",
+						baseBranch: "develop",
+						triggerLabel: "autofix",
+					},
+				],
+				token: "ghp_testtoken",
+				botUsername: "fixbot-app",
+			},
+			webhook: {
+				enabled: true,
+				port: 19876,
+				secret: overrides?.secret ?? TEST_SECRET,
+				...(overrides?.rateLimitPerRepoPerMin
+					? { rateLimitPerRepoPerMin: overrides.rateLimitPerRepoPerMin }
+					: {}),
+			},
+		},
+		"<inline>",
+	);
+	// Override port to 0 so Bun picks a random available port (bypass config validation)
+	if (baseConfig.webhook) {
+		(baseConfig.webhook as any).port = 0;
+	}
+	return baseConfig;
+}
+
+function cleanupDir(config: NormalizedDaemonConfigV1): void {
+	try {
+		rmSync(config.paths.stateDir, { recursive: true, force: true });
+		rmSync(config.paths.resultsDir, { recursive: true, force: true });
+	} catch {
+		// Ignore cleanup failures in tests
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Signature verification
+// ---------------------------------------------------------------------------
+
+describe("verifyWebhookSignature", () => {
+	it("accepts valid HMAC-SHA256 signature", () => {
+		const payload = '{"action":"labeled"}';
+		const sig = signPayload(payload, TEST_SECRET);
+		expect(verifyWebhookSignature(payload, sig, TEST_SECRET)).toBe(true);
+	});
+
+	it("rejects invalid signature", () => {
+		const payload = '{"action":"labeled"}';
+		const sig = signPayload(payload, "wrong-secret");
+		expect(verifyWebhookSignature(payload, sig, TEST_SECRET)).toBe(false);
+	});
+
+	it("rejects missing sha256= prefix", () => {
+		const payload = '{"action":"labeled"}';
+		const hex = createHmac("sha256", TEST_SECRET).update(payload).digest("hex");
+		expect(verifyWebhookSignature(payload, hex, TEST_SECRET)).toBe(false);
+	});
+
+	it("rejects empty signature", () => {
+		expect(verifyWebhookSignature("{}", "", TEST_SECRET)).toBe(false);
+	});
+
+	it("rejects tampered payload", () => {
+		const payload = '{"action":"labeled"}';
+		const sig = signPayload(payload, TEST_SECRET);
+		expect(verifyWebhookSignature('{"action":"opened"}', sig, TEST_SECRET)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiter
+// ---------------------------------------------------------------------------
+
+describe("SlidingWindowRateLimiter", () => {
+	it("allows requests within limit", () => {
+		const limiter = new SlidingWindowRateLimiter(3, 60_000);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(true);
+	});
+
+	it("rejects requests over limit", () => {
+		const limiter = new SlidingWindowRateLimiter(2, 60_000);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(false);
+	});
+
+	it("tracks repos independently", () => {
+		const limiter = new SlidingWindowRateLimiter(1, 60_000);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-b")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(false);
+		expect(limiter.allow("repo-b")).toBe(false);
+	});
+
+	it("reset clears all buckets", () => {
+		const limiter = new SlidingWindowRateLimiter(1, 60_000);
+		expect(limiter.allow("repo-a")).toBe(true);
+		expect(limiter.allow("repo-a")).toBe(false);
+		limiter.reset();
+		expect(limiter.allow("repo-a")).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// findRepoConfig
+// ---------------------------------------------------------------------------
+
+describe("findRepoConfig", () => {
+	it("finds repo config by full name", () => {
+		const config = makeTestConfig();
+		const found = findRepoConfig(config, "testowner/testrepo");
+		expect(found).toBeDefined();
+		expect(found!.url).toBe("https://github.com/testowner/testrepo");
+		cleanupDir(config);
+	});
+
+	it("finds repo config case-insensitively", () => {
+		const config = makeTestConfig();
+		const found = findRepoConfig(config, "TestOwner/TestRepo");
+		expect(found).toBeDefined();
+		expect(found!.url).toBe("https://github.com/testowner/testrepo");
+		cleanupDir(config);
+	});
+
+	it("returns undefined for unconfigured repo", () => {
+		const config = makeTestConfig();
+		const found = findRepoConfig(config, "unknown/repo");
+		expect(found).toBeUndefined();
+		cleanupDir(config);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// deriveWebhookJobId
+// ---------------------------------------------------------------------------
+
+describe("deriveWebhookJobId", () => {
+	it("produces deterministic IDs with wh- prefix", () => {
+		const id = deriveWebhookJobId("https://github.com/o/r", 42, "delivery-123");
+		expect(id).toMatch(/^wh-[a-f0-9]{16}$/);
+	});
+
+	it("produces different IDs for different delivery IDs", () => {
+		const id1 = deriveWebhookJobId("https://github.com/o/r", 42, "delivery-1");
+		const id2 = deriveWebhookJobId("https://github.com/o/r", 42, "delivery-2");
+		expect(id1).not.toBe(id2);
+	});
+
+	it("produces different IDs for different issues", () => {
+		const id1 = deriveWebhookJobId("https://github.com/o/r", 1, "delivery-1");
+		const id2 = deriveWebhookJobId("https://github.com/o/r", 2, "delivery-1");
+		expect(id1).not.toBe(id2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// routeWebhookEvent
+// ---------------------------------------------------------------------------
+
+describe("routeWebhookEvent", () => {
+	it("routes issues.labeled to enqueue", () => {
+		const config = makeTestConfig();
+		const logger = createCapturingLogger();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "labeled",
+				issue: { number: 10, title: "Fix bug", body: "Details here" },
+				label: { name: "fixbot" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-abc",
+			logger,
+		);
+
+		expect(envelope).not.toBeNull();
+		expect(envelope!.submission.kind).toBe("github-webhook");
+		expect(envelope!.submission.githubRepo).toBe("testowner/testrepo");
+		expect(envelope!.submission.githubIssueNumber).toBe(10);
+		expect(envelope!.submission.githubDeliveryId).toBe("delivery-abc");
+		expect(envelope!.submission.githubLabelName).toBe("fixbot");
+		expect(envelope!.job.taskClass).toBe("solve_issue");
+		cleanupDir(config);
+	});
+
+	it("routes issues.labeled with taskClassOverride", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "labeled",
+				issue: { number: 10, title: "CI broken", body: null },
+				label: { name: "fixbot:ci" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-def",
+		);
+
+		expect(envelope).not.toBeNull();
+		expect(envelope!.job.taskClass).toBe("fix_ci");
+		cleanupDir(config);
+	});
+
+	it("ignores issues.labeled for non-matching label", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "labeled",
+				issue: { number: 10, title: "Bug", body: null },
+				label: { name: "unrelated-label" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-ghi",
+		);
+
+		expect(envelope).toBeNull();
+		cleanupDir(config);
+	});
+
+	it("ignores events for unconfigured repos", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "labeled",
+				issue: { number: 10, title: "Bug", body: null },
+				label: { name: "fixbot" },
+				repository: { full_name: "unknown/repo" },
+			},
+			config,
+			"delivery-jkl",
+		);
+
+		expect(envelope).toBeNull();
+		cleanupDir(config);
+	});
+
+	it("routes issues.assigned when assignee matches botUsername", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "assigned",
+				issue: { number: 5, title: "Assigned bug", body: "Fix this" },
+				assignee: { login: "fixbot-app" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-mno",
+		);
+
+		expect(envelope).not.toBeNull();
+		expect(envelope!.submission.kind).toBe("github-webhook");
+		expect(envelope!.job.taskClass).toBe("solve_issue");
+		cleanupDir(config);
+	});
+
+	it("ignores issues.assigned when assignee does not match botUsername", () => {
+		const config = makeTestConfig();
+		const logger = createCapturingLogger();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "assigned",
+				issue: { number: 5, title: "Assigned bug", body: "Fix this" },
+				assignee: { login: "some-human" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-mno-skip",
+			logger,
+		);
+
+		expect(envelope).toBeNull();
+		expect(logger.lines.some((l) => l.includes("not bot user"))).toBe(true);
+		cleanupDir(config);
+	});
+
+	it("ignores issues.assigned when botUsername is not configured", () => {
+		const config = makeTestConfig();
+		// Remove botUsername
+		if (config.github) {
+			(config.github as any).botUsername = undefined;
+		}
+		const logger = createCapturingLogger();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "assigned",
+				issue: { number: 5, title: "Assigned bug", body: "Fix this" },
+				assignee: { login: "fixbot-app" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-mno-nobot",
+			logger,
+		);
+
+		expect(envelope).toBeNull();
+		expect(logger.lines.some((l) => l.includes("no github.botUsername configured"))).toBe(true);
+		cleanupDir(config);
+	});
+
+	it("routes pull_request_review_comment.created", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"pull_request_review_comment",
+			{
+				action: "created",
+				pull_request: { number: 99, title: "PR title", body: "PR body" },
+				comment: { body: "Please fix this" },
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-pqr",
+		);
+
+		expect(envelope).not.toBeNull();
+		expect(envelope!.submission.kind).toBe("github-webhook");
+		expect(envelope!.submission.githubIssueNumber).toBe(99);
+		cleanupDir(config);
+	});
+
+	it("ignores unhandled event types", () => {
+		const config = makeTestConfig();
+		const logger = createCapturingLogger();
+		const envelope = routeWebhookEvent(
+			"push",
+			{
+				action: "completed",
+				repository: { full_name: "testowner/testrepo" },
+			},
+			config,
+			"delivery-stu",
+			logger,
+		);
+
+		expect(envelope).toBeNull();
+		expect(logger.lines.some((l) => l.includes("ignoring unhandled event"))).toBe(true);
+		cleanupDir(config);
+	});
+
+	it("routes issues.labeled for second configured repo", () => {
+		const config = makeTestConfig();
+		const envelope = routeWebhookEvent(
+			"issues",
+			{
+				action: "labeled",
+				issue: { number: 7, title: "Other project bug", body: null },
+				label: { name: "autofix" },
+				repository: { full_name: "other/project" },
+			},
+			config,
+			"delivery-vwx",
+		);
+
+		expect(envelope).not.toBeNull();
+		expect(envelope!.submission.githubRepo).toBe("other/project");
+		cleanupDir(config);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// HTTP server integration tests
+// ---------------------------------------------------------------------------
+
+describe("webhook HTTP server", () => {
+	let server: WebhookServer;
+	let config: NormalizedDaemonConfigV1;
+	let baseUrl: string;
+
+	beforeEach(() => {
+		config = makeTestConfig();
+		const logger = createCapturingLogger();
+		server = createWebhookServer({
+			config,
+			webhookConfig: config.webhook!,
+			logger,
+		});
+		baseUrl = `http://localhost:${server.port}`;
+	});
+
+	afterEach(async () => {
+		await server.stop();
+		cleanupDir(config);
+	});
+
+	it("responds to /healthz with metrics", async () => {
+		const res = await fetch(`${baseUrl}/healthz`);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe("ok");
+		expect(body.receivedCount).toBe(0);
+	});
+
+	it("rejects GET to /webhook", async () => {
+		const res = await fetch(`${baseUrl}/webhook`);
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects POST to unknown path", async () => {
+		const res = await fetch(`${baseUrl}/unknown`, { method: "POST" });
+		expect(res.status).toBe(404);
+	});
+
+	it("rejects POST with invalid signature", async () => {
+		const payload = JSON.stringify({
+			action: "labeled",
+			issue: { number: 1, title: "t", body: null },
+			label: { name: "fixbot" },
+			repository: { full_name: "testowner/testrepo" },
+		});
+		const res = await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": "sha256=invalid",
+				"x-github-event": "issues",
+				"x-github-delivery": "test-delivery",
+			},
+		});
+		expect(res.status).toBe(401);
+		expect(server.metrics.rejectedCount).toBe(1);
+	});
+
+	it("rejects POST with missing event header", async () => {
+		const payload = JSON.stringify({
+			action: "labeled",
+			repository: { full_name: "testowner/testrepo" },
+		});
+		const sig = signPayload(payload, TEST_SECRET);
+		const res = await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": sig,
+			},
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it("accepts valid issues.labeled and enqueues job", async () => {
+		const payload = JSON.stringify({
+			action: "labeled",
+			issue: { number: 42, title: "Fix memory leak", body: "Details" },
+			label: { name: "fixbot" },
+			repository: { full_name: "testowner/testrepo" },
+		});
+		const sig = signPayload(payload, TEST_SECRET);
+		const res = await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": sig,
+				"x-github-event": "issues",
+				"x-github-delivery": "delivery-001",
+			},
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe("queued");
+		expect(body.jobId).toBeDefined();
+		expect(body.deliveryId).toBe("delivery-001");
+		expect(server.metrics.acceptedCount).toBe(1);
+	});
+
+	it("returns duplicate for same delivery replayed", async () => {
+		const payload = JSON.stringify({
+			action: "labeled",
+			issue: { number: 42, title: "Fix memory leak", body: "Details" },
+			label: { name: "fixbot" },
+			repository: { full_name: "testowner/testrepo" },
+		});
+		const sig = signPayload(payload, TEST_SECRET);
+		const headers = {
+			"x-hub-signature-256": sig,
+			"x-github-event": "issues",
+			"x-github-delivery": "delivery-dup",
+		};
+
+		const res1 = await fetch(`${baseUrl}/webhook`, { method: "POST", body: payload, headers });
+		expect(res1.status).toBe(200);
+		const body1 = await res1.json();
+		expect(body1.status).toBe("queued");
+
+		// Same delivery ID produces same job ID → duplicate
+		const res2 = await fetch(`${baseUrl}/webhook`, { method: "POST", body: payload, headers });
+		expect(res2.status).toBe(200);
+		const body2 = await res2.json();
+		expect(body2.status).toBe("duplicate");
+	});
+
+	it("returns ignored for unmatched event", async () => {
+		const payload = JSON.stringify({
+			action: "opened",
+			repository: { full_name: "testowner/testrepo" },
+		});
+		const sig = signPayload(payload, TEST_SECRET);
+		const res = await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": sig,
+				"x-github-event": "push",
+				"x-github-delivery": "delivery-ignored",
+			},
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe("ignored");
+	});
+
+	it("rate limits excessive requests per repo", async () => {
+		// Create server with very low rate limit
+		await server.stop();
+		cleanupDir(config);
+		config = makeTestConfig({ rateLimitPerRepoPerMin: 2 });
+		server = createWebhookServer({
+			config,
+			webhookConfig: config.webhook!,
+		});
+		baseUrl = `http://localhost:${server.port}`;
+
+		async function sendEvent(deliveryId: string): Promise<Response> {
+			const payload = JSON.stringify({
+				action: "labeled",
+				issue: { number: 100, title: "Rate test", body: null },
+				label: { name: "fixbot" },
+				repository: { full_name: "testowner/testrepo" },
+			});
+			return fetch(`${baseUrl}/webhook`, {
+				method: "POST",
+				body: payload,
+				headers: {
+					"x-hub-signature-256": signPayload(payload, TEST_SECRET),
+					"x-github-event": "issues",
+					"x-github-delivery": deliveryId,
+				},
+			});
+		}
+
+		const r1 = await sendEvent("rl-1");
+		expect(r1.status).toBe(200);
+
+		const r2 = await sendEvent("rl-2");
+		expect(r2.status).toBe(200);
+
+		// Third should be rate limited
+		const r3 = await sendEvent("rl-3");
+		expect(r3.status).toBe(429);
+		expect(server.metrics.rateLimitedCount).toBe(1);
+	});
+
+	it("tracks metrics across multiple requests", async () => {
+		// Valid request
+		const payload = JSON.stringify({
+			action: "labeled",
+			issue: { number: 1, title: "t", body: null },
+			label: { name: "fixbot" },
+			repository: { full_name: "testowner/testrepo" },
+		});
+		await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": signPayload(payload, TEST_SECRET),
+				"x-github-event": "issues",
+				"x-github-delivery": "metrics-1",
+			},
+		});
+
+		// Invalid signature
+		await fetch(`${baseUrl}/webhook`, {
+			method: "POST",
+			body: payload,
+			headers: {
+				"x-hub-signature-256": "sha256=bad",
+				"x-github-event": "issues",
+				"x-github-delivery": "metrics-2",
+			},
+		});
+
+		const m = server.metrics;
+		expect(m.receivedCount).toBe(2);
+		expect(m.acceptedCount).toBe(1);
+		expect(m.rejectedCount).toBe(1);
+		expect(m.lastReceivedAt).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- Adds HTTP webhook server (`/webhook` endpoint) for receiving GitHub events with HMAC-SHA256 signature verification, per-repo sliding-window rate limiting, and event routing to the daemon job queue
- Supports `issues.labeled`, `issues.assigned`, and `pull_request_review_comment.created` events; `issues.assigned` checks `payload.assignee.login` against `config.github.botUsername` before triggering
- Integrates webhook lifecycle (start/stop) into the daemon service, with new types (`DaemonWebhookConfig`, `NormalizedDaemonWebhookConfig`, `WebhookHealthMetrics`, `"github-webhook"` submission kind) and config normalization

## Test plan
- [x] 35 webhook tests pass (signature verification, rate limiting, event routing, HTTP integration, duplicate detection)
- [x] 25 daemon-config tests pass (webhook config parsing, defaults, validation, backward compatibility, github-webhook submission kind)
- [ ] Manual: configure `webhook.enabled: true` with a secret and verify `/healthz` responds
- [ ] Manual: send signed GitHub webhook payloads and verify jobs are enqueued

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)